### PR TITLE
[Hotfix] Fix working directory in which the gh-pages generation runs

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -1,5 +1,9 @@
 name: Deploy to GitHub Pages
 
+defaults:
+  run:
+    working-directory: ./docs
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Description

- Fix working directory in which the gh-pages generation runs

## Checklist

Before you move on, make sure that:

- [x ] No unintended changes are included
- [x ] Spelling is correct
- [x ] There are tests covering new/changed functionality
- [x ] Rubocop style is passing, and Rspec tests are passing.
- [x ] Documentation has been written (Docs or code)
- [x ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x ] Proper labels assigned. Use `WIP` label to indicate that state
