### PR TITLE
[Hotfix] Upgrade Postgres Configuration

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -21,10 +21,9 @@ jobs:
       postgres:
         image: postgres:13-alpine
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: ""
+          POSTGRES_USER: cenabast
+          POSTGRES_PASSWORD: yourpassword
           POSTGRES_DB: cenabast_test
-          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
         - 5432:5432
         # needed because the postgres container does not provide a healthcheck

--- a/bin/setup-docker
+++ b/bin/setup-docker
@@ -8,6 +8,17 @@ export DB_HOST=127.0.0.1
 export DB_PORT=5432
 bin/start-db-redis-containers
 
+export DATABASE_VOLUME_NAME="cenabast-postgres"
+
+# Check if the Docker volume already exists
+if docker volume inspect $DATABASE_VOLUME_NAME > /dev/null 2>&1; then
+    echo "Docker volume '$DATABASE_VOLUME_NAME' already exists."
+else
+    # Create the Docker volume
+    docker volume create $DATABASE_VOLUME_NAME
+    echo "Docker volume '$DATABASE_VOLUME_NAME' created successfully."
+fi
+
 docker compose run --rm web bash -c '
   bin/wait-for-services &&
   (bundle check || bundle install) &&

--- a/config/database.yml
+++ b/config/database.yml
@@ -25,7 +25,8 @@ development:
   <<: *default
   database: cenabast_development
   host: <%= ENV.fetch('DB_HOST', 'localhost') %>
-  username: <%= ENV.fetch('DB_USER', 'postgres') %>
+  password: <%= ENV.fetch('DB_PASSWORD', 'yourpassword') %>
+  username: <%= ENV.fetch('DB_USER', 'cenabast') %>
   port: <%= ENV.fetch('DB_PORT', '5432') %>
 
   # The specified database role being used to connect to postgres.
@@ -62,7 +63,8 @@ test:
   <<: *default
   database: cenabast_test
   host: <%= ENV.fetch('DB_HOST', 'localhost') %>
-  username: <%= ENV.fetch('DB_USER', 'postgres') %>
+  password: <%= ENV.fetch('DB_PASSWORD', 'yourpassword') %>
+  username: <%= ENV.fetch('DB_USER', 'cenabast') %>
   port: <%= ENV.fetch('DB_PORT', '5432') %>
 
 # As with config/secrets.yml, you never want to store sensitive information,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
 version: '3.7'
 services:
   postgres:
-    image: postgres:13-alpine
+    image: postgres:15-alpine
     environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: "cenabast"
+      POSTGRES_PASSWORD: "yourpassword"
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - 'cenabast-postgres:/var/lib/postgresql/data'
 
@@ -31,6 +32,8 @@ services:
       - 'bundle_cache:/bundle'
       - '.:/app'
       - .env:/app/.env
+    stdin_open: true
+    tty: true
     environment:
       REDIS_URL: redis://redis:6379/0
       DB_HOST: postgres
@@ -86,7 +89,8 @@ services:
       - opensearch
 
 volumes:
-  redis:
   cenabast-postgres:
-  bundle_cache:
+    external: true
   opensearch-data:
+  redis:
+  bundle_cache:


### PR DESCRIPTION
## Description
Upgrades postgres configuration to improve security and to use a more recent version of the database.

- Upgrade postgres version to 15
- Disabled POSTGRES_HOST_AUTH_METHOD trust configuration, use password instead
- Limit postgres service exposure to 127.0.0.1
- Marked Postgres volume as external

## Checklist

Before you move on, make sure that:

- [x ] No unintended changes are included
- [x ] Spelling is correct
- [x ] There are tests covering new/changed functionality
- [x ] Rubocop style is passing, and Rspec tests are passing.
- [x ] Documentation has been written (Docs or code)
- [x ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x ] Proper labels assigned. Use `WIP` label to indicate that state
