### PR TITLE
[PE188-56] Adjust SMTP and ActiveStorage configuration

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,9 @@
+---
+ignore:
+  # (2024/02/12) Ignore jQuery CVEs
+  # jquery-ui-rails version 7.0 still hasnt been released on rubygems
+  # and the current release of spree_backend doesnt support
+  # tagged version 7.0
+  - CVE-2021-41182
+  - CVE-2021-41183
+  - CVE-2021-41184

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,11 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 4.0'
 
+  # Preview mail in the browser instead of sending.
   gem 'letter_opener'
+
+  # Gives letter_opener an interface for browsing sent emails.
+  gem 'letter_opener_web', '~> 2.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,6 +329,11 @@ GEM
       addressable (~> 2.8)
     letter_opener (1.8.1)
       launchy (>= 2.2, < 3)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -820,6 +825,7 @@ DEPENDENCIES
   font_assets
   jsbundling-rails
   letter_opener
+  letter_opener_web (~> 2.0)
   listen
   lookbook (>= 2.2.0)
   memory_profiler

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ bin/start-docker
 By default, webserver will be exposed on port 4000.
 Opensearch dashboard will be exposed on port 5601.
 
+
+In developer environment, Lookbook UI is accesible via `/lookbook` path.
+Mails are sent using `letter_oppener`, Web UI is accesible via `/letter_opener` path.
+
 ### Install tools for style/security checks locally and to run Git hooks (Overcommit)
 
 ```
@@ -177,7 +181,7 @@ Important: Spree::Store `mail_from_address` must be set to a corresponding value
 
 ## Useful links
 
-### Documentation
+### Documentation (Developer guidelines, Business logic definition)
 https://departamento-ti.github.io/cenabast-tienda/
 
 ### Mercado publico quotation detail (Has documentation for project requirements)

--- a/README.md
+++ b/README.md
@@ -149,6 +149,32 @@ Developers conduct code reviews before merging into the main branch.
 Branch must pass the pipeline validations.
 And a corresponding test coverage must be added into the branch.
 
+## Env variables
+
+For local environments, env variables are copied automatically upon setup. Using .env.sample as the base.
+
+Some additional environment variables might be needed to be set for pre-productive/productive environments:
+
+**Storage Bucket configuration (Store attachments in S3)**
+```
+BUCKET_NAME
+ACCESS_KEY_ID
+SECRET_ACCESS_KEY
+SMTP_ADDRESS
+```
+
+**SMTP Email configuration (Send mails using SMTP service ie. SES)**
+```
+SMTP_PORT
+SMTP_DOMAIN
+SMTP_USERNAME
+SMTP_PASSWORD
+SMTP_AUTH
+SMTP_ENABLE_STARTTLS_AUTO
+```
+
+Important: Spree::Store `mail_from_address` must be set to a corresponding value (email address of sender, that matches domain of the STMP configuration).
+
 ## Useful links
 
 ### Documentation

--- a/app/helpers/cenabast/spree/admin/stores_helper_decorator.rb
+++ b/app/helpers/cenabast/spree/admin/stores_helper_decorator.rb
@@ -1,0 +1,27 @@
+module Cenabast
+  module Spree
+    module Admin
+      module StoresHelperDecorator
+        # This helper is used to build the link to switch to each store on the backend
+        # interface
+        # We decorated this in order to use the toggle_store_path, and
+        # then change the user current_store preference
+        def store_switcher_link(store)
+          if current_store.id == store.id
+            classes = 'disabled bg-light'
+            icon = svg_icon name: 'circle-fill.svg', width: '18', height: '18'
+          else
+            classes = nil
+            icon = svg_icon name: 'circle.svg', width: '18', height: '18'
+          end
+
+          link_to icon + store.unique_name, Rails.application.routes.url_helpers.toggle_store_path(option_id: store.id),
+                  class: "#{classes} py-3 px-4 dropdown-item rounded", method: :post, data: { turbo: false }
+        end
+      end
+    end
+  end
+end
+
+not_included = Spree::Admin::StoresHelper.included_modules.exclude?(Cenabast::Spree::Admin::StoresHelperDecorator)
+Spree::Admin::StoresHelper.prepend Cenabast::Spree::Admin::StoresHelperDecorator if not_included

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,5 +53,19 @@ module SpreeStarter
       require "#{Rails.root}/lib/cloud_flare_middleware"
       config.middleware.insert_before(0, Rack::CloudFlareMiddleware)
     end
+
+    # SMTP mail
+    if ENV['SMTP_USERNAME'].present?
+      config.action_mailer.delivery_method = :smtp
+      config.action_mailer.smtp_settings = {
+        address:              ENV["SMTP_ADDRESS"],
+        port:                 ENV["SMTP_PORT"].to_i,
+        domain:               ENV["SMTP_DOMAIN"],
+        user_name:            ENV["SMTP_USERNAME"],
+        password:             ENV["SMTP_PASSWORD"],
+        authentication:       ENV["SMTP_AUTH"] || 'plain',
+        enable_starttls_auto: ENV["SMTP_ENABLE_STARTTLS_AUTO"] == "true"
+      }
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,13 @@ module SpreeStarter
       config.middleware.insert_before(0, Rack::CloudFlareMiddleware)
     end
 
+    # Store uploaded files on the local file system (see config/storage.yml for options).
+    if ENV['ACCESS_KEY_ID'].present? && ENV['SECRET_ACCESS_KEY'].present?
+      config.active_storage.service = :amazon
+    else
+      config.active_storage.service = :local
+    end
+
     # SMTP mail
     if ENV['SMTP_USERNAME'].present?
       config.action_mailer.delivery_method = :smtp

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,9 +33,6 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
-
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,8 +73,10 @@ Rails.application.configure do
     end
   end
 
-  config.action_mailer.delivery_method = :letter_opener
-  config.action_mailer.perform_deliveries = true
+  unless ENV['SMTP_USERNAME'].present?
+    config.action_mailer.delivery_method = :letter_opener
+    config.action_mailer.perform_deliveries = true
+  end
 
   routes.default_url_options = config.action_mailer.default_url_options = {
     host: ENV.fetch('APPLICATION_HOST', 'localhost'),

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,13 +39,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  if ENV['BUCKETEER_AWS_ACCESS_KEY_ID'].present? && ENV['BUCKETEER_AWS_SECRET_ACCESS_KEY'].present?
-    config.active_storage.service = :amazon
-  else
-    config.active_storage.service = :local
-  end
-
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -133,15 +133,6 @@ Rails.application.configure do
     config.logger = ActiveSupport::TaggedLogging.new remote_syslog_logger
   end
 
-  # sendgrid mail
-  if ENV['SENDGRID_API_KEY'].present?
-    config.action_mailer.delivery_method = :sendgrid_actionmailer
-    config.action_mailer.sendgrid_actionmailer_settings = {
-      api_key: ENV['SENDGRID_API_KEY'],
-      raise_delivery_errors: true
-    }
-  end
-
   # fix for fonts CORS issues with CloudFront
   config.font_assets.origin = '*'
   # Do not dump schema after migrations.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,6 @@ Rails.application.routes.draw do
 
   if Rails.env.development?
     mount Lookbook::Engine, at: '/lookbook'
+    mount LetterOpenerWeb::Engine, at: '/letter_opener'
   end
 end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -11,10 +11,10 @@ local:
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 amazon:
   service: S3
-  access_key_id: <%= ENV['BUCKETEER_AWS_ACCESS_KEY_ID'] %>
-  secret_access_key: <%= ENV['BUCKETEER_AWS_SECRET_ACCESS_KEY'] %>
-  region: <%= ENV['BUCKETEER_AWS_REGION'] %>
-  bucket: <%= ENV['BUCKETEER_BUCKET_NAME'] %>
+  region: <%= ENV["AWS_REGION"] || 'us-east-1' %>
+  bucket: <%= ENV["BUCKET_NAME"] %>
+  access_key_id: <%= ENV["ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["SECRET_ACCESS_KEY"] %>
   public: true
   upload:
     cache_control: 'public, max-age=31536000'

--- a/spec/requests/cenabast/spree/user_preferences_spec.rb
+++ b/spec/requests/cenabast/spree/user_preferences_spec.rb
@@ -5,8 +5,14 @@ RSpec.describe Cenabast::Spree::UserPreferencesController, type: :request do
     let(:user) { create(:user) }
     let(:stores) { create_list(:store, 3) }
 
+    before do
+      allow_any_instance_of(Spree::StoreController).to receive(:try_spree_current_user).and_return(user)
+      allow_any_instance_of(Spree::StoreController).to receive_messages spree_current_user: user
+    end
+
     it 'can toggle the store to an allowed one' do
       user.availiable_stores << stores
+      user.save
       store = stores.sample
 
       post toggle_store_path(option_id: store.id)


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- https://linets.atlassian.net/browse/PE188-56

## Description

Adjusts SMTP and ActiveStorage configuration to use provided SES and S3 credentials
If credentials arent given, it will default to local storage, and mail delivery using letter_opener.

- Add letter_opener_web for development environments
- Add description of env vars that are needed to configure S3/SES in README
- Adds StoresHelperDecorator for allow shop switch in the backend too
- Add ignore of (currently unfixable) jquery CVEs [BundleAudit]
- Fix flaky request spec [UserPreferencesController request spec]

## Checklist

Before you move on, make sure that:

- [x ] No unintended changes are included
- [x ] Spelling is correct
- [x ] There are tests covering new/changed functionality
- [x ] Rubocop style is passing, and Rspec tests are passing.
- [x ] Documentation has been written (Docs or code)
- [x ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x ] Proper labels assigned. Use `WIP` label to indicate that state
