### PR TITLE
[PE188-12] Change opensearch to elasticsearch

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -8,3 +8,6 @@ ignore:
   - CVE-2021-41183
   - CVE-2021-41184
   - CVE-2022-31160
+  # (2024/02/27) Ignore rack-cors CVEs
+  # No patch for rack-cors has been available yet.
+  - CVE-2024-27456

--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,8 @@
 # General settings
 DISABLE_SPRING=1
 
-# Opensearch
-OPENSEARCH_URL=http://opensearch:9200
+# Elasticsearch
+ELASTICSEARCH_URL=http://elasticsearch-oss:9200
 
 # Redis
 REDIS_URL=redis://redis:6379/0
@@ -22,3 +22,20 @@ CENABAST_API_BASE_URL=https://testaplicacionesweb.cenabast.cl:7001
 CENABAST_API_USER=tienda
 CENABAST_API_PASSWORD="tienda#2024"
 CENABAST_API_TOKEN_EXPIRE_TIME=30
+
+# Elasticsearch and Kibana
+
+# Password for the 'elastic' user (at least 6 characters)
+ELASTIC_PASSWORD=elastic_password
+
+# Password for the 'kibana_system' user (at least 6 characters)
+KIBANA_PASSWORD=kibana_password
+
+# Set the cluster name
+CLUSTER_NAME=docker-cluster
+
+# Port to expose Elasticsearch HTTP API to the host
+ES_PORT=9200
+
+# Port to expose Kibana to the host
+KIBANA_PORT=5601

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -7,17 +7,24 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      opensearch:
-        image: opensearchproject/opensearch:2
-        env:
-          discovery.type: single-node
-          node.name: opensearch
-          # Disables Security plugin
-          DISABLE_SECURITY_PLUGIN: 'true'
-          OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
+      elasticsearch-oss:
+        image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+        container_name: elasticsearch-oss
+        restart: unless-stopped
+        hostname: elasticsearch
+        ulimits:
+          memlock:
+            soft: -1
+            hard: -1
         ports:
           - 9200:9200
-          - 9600:9600
+        environment:
+          DISABLE_SECURITY_PLUGIN: 'true'
+          ES_JAVA_OPTS: '-Xms512m -Xmx512m'
+          cluster.name: cenabast
+          ELASTIC_PASSWORD: elastic_password
+          discovery.type: 'single-node'
+          network.host: 0.0.0.0
       postgres:
         image: postgres:13-alpine
         env:
@@ -49,4 +56,4 @@ jobs:
         RAILS_ENV: test
         DB_HOST: localhost
         DB_PORT: ${{ job.services.postgres.ports[5432] }}
-        OPENSEARCH_URL: http://localhost:${{ job.services.opensearch.ports[9200] }}
+        ELASTICSEARCH_URL: http://localhost:${{ job.services.elasticsearch-oss.ports[9200] }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -9,16 +9,9 @@ jobs:
     services:
       elasticsearch-oss:
         image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
-        container_name: elasticsearch-oss
-        restart: unless-stopped
-        hostname: elasticsearch
-        ulimits:
-          memlock:
-            soft: -1
-            hard: -1
         ports:
           - 9200:9200
-        environment:
+        env:
           DISABLE_SECURITY_PLUGIN: 'true'
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
           cluster.name: cenabast

--- a/Gemfile
+++ b/Gemfile
@@ -162,11 +162,9 @@ gem 'slim_lint', require: false, group: %w[test development]
 # Intelligent search made easy
 gem 'searchkick'
 
-# Ruby Client for OpenSearch
-gem 'opensearch-ruby'
-
-# Rack CORS Middleware
-gem 'rack-cors'
+# Ruby Client for ElasticSearch
+# https://github.com/ankane/searchkick/issues/1550
+gem 'elasticsearch', '< 7.14'
 
 # SendGrid
 gem 'sendgrid-actionmailer'

--- a/Gemfile
+++ b/Gemfile
@@ -166,6 +166,9 @@ gem 'searchkick'
 # https://github.com/ankane/searchkick/issues/1550
 gem 'elasticsearch', '< 7.14'
 
+# Rack CORS Middleware
+gem 'rack-cors'
+
 # SendGrid
 gem 'sendgrid-actionmailer'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -461,6 +461,8 @@ GEM
     rack (3.0.9.1)
     rack-cache (1.14.0)
       rack (>= 0.4)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-mini-profiler (3.1.1)
       rack (>= 1.2.0)
     rack-protection (4.0.0)
@@ -883,6 +885,7 @@ DEPENDENCIES
   pg
   puma (>= 6.4.2)
   rack-cache
+  rack-cors
   rack-mini-profiler
   rack-timeout
   rails (~> 7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,14 @@ GEM
       railties (>= 3.2)
     drb (2.2.0)
       ruby2_keywords
+    elasticsearch (7.4.0)
+      elasticsearch-api (= 7.4.0)
+      elasticsearch-transport (= 7.4.0)
+    elasticsearch-api (7.4.0)
+      multi_json
+    elasticsearch-transport (7.4.0)
+      faraday
+      multi_json
     erubi (1.12.0)
     execjs (2.9.1)
     factory_bot (4.11.1)
@@ -424,9 +432,6 @@ GEM
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
-    opensearch-ruby (3.1.0)
-      faraday (>= 1.0, < 3)
-      multi_json (>= 1.0)
     orm_adapter (0.5.0)
     parallel (1.23.0)
     paranoia (2.6.3)
@@ -456,8 +461,6 @@ GEM
     rack (3.0.9.1)
     rack-cache (1.14.0)
       rack (>= 0.4)
-    rack-cors (2.0.1)
-      rack (>= 2.0.0)
     rack-mini-profiler (3.1.1)
       rack (>= 1.2.0)
     rack-protection (4.0.0)
@@ -864,6 +867,7 @@ DEPENDENCIES
   database_cleaner-active_record
   debug (>= 1.0.0)
   dotenv-rails (~> 2.1, >= 2.1.1)
+  elasticsearch (< 7.14)
   flamegraph
   font_assets
   jsbundling-rails
@@ -876,11 +880,9 @@ DEPENDENCIES
   omniauth
   omniauth-oauth2
   omniauth-rails_csrf_protection
-  opensearch-ruby
   pg
   puma (>= 6.4.2)
   rack-cache
-  rack-cors
   rack-mini-profiler
   rack-timeout
   rails (~> 7.1)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ bin/start-docker
 ```
 
 By default, webserver will be exposed on port 4000.
-Opensearch dashboard will be exposed on port 5601.
+Kibana dashboard will be exposed on port 5601.
 MageAI dashboard will be exposed on port 6789.
 
 In developer environment, Lookbook UI is accesible via `/lookbook` path.
@@ -76,7 +76,7 @@ gem install slim_lint -v 0.26.0
 overcommit --install
 ```
 
-## Opensearch Dashboard simple usage
+## Kibana Dashboard simple usage
 
 The default URL should be
 http://localhost:5601/
@@ -84,17 +84,17 @@ http://localhost:5601/
 Default credentials are
 
 ```
-username: admin
-password: admin
+username: elastic
+password: elastic_password
 ```
 
 In order to be able to browse data, create an index pattern for `spree_variants_development` on:
 
-http://localhost:5601/app/management/opensearch-dashboards/indexPatterns
+http://localhost:5601/app/management/kibana/indexPatterns/create
 
 Then you can use Data Explorer > Discover to view existing records:
 
-http://localhost:5601/app/data-explorer/discover
+http://localhost:5601/app/discover
 
 ## Run tests
 
@@ -159,6 +159,15 @@ And a corresponding test coverage must be added into the branch.
 For local environments, env variables are copied automatically upon setup. Using .env.sample as the base.
 
 Some additional environment variables might be needed to be set for pre-productive/productive environments:
+
+**Elasticsearch configuration**
+```
+ELASTIC_PASSWORD
+KIBANA_PASSWORD
+CLUSTER_NAME
+ES_PORT
+KIBANA_PORT
+```
 
 **Storage Bucket configuration (Store attachments in S3)**
 ```

--- a/app/finders/cenabast/spree/stores/find_current.rb
+++ b/app/finders/cenabast/spree/stores/find_current.rb
@@ -10,6 +10,7 @@ module Cenabast
         def initialize(scope: nil, current_user: nil)
           @scope = scope || ::Spree::Store
           @current_user = current_user
+          # test
         end
 
         def execute

--- a/app/finders/cenabast/spree/stores/find_current.rb
+++ b/app/finders/cenabast/spree/stores/find_current.rb
@@ -10,7 +10,6 @@ module Cenabast
         def initialize(scope: nil, current_user: nil)
           @scope = scope || ::Spree::Store
           @current_user = current_user
-          # test
         end
 
         def execute

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,8 @@
 version: '3.7'
+
+include:
+  - elasticsearch-compose.yml
+
 services:
   postgres:
     image: postgres:15-alpine
@@ -21,7 +25,7 @@ services:
     depends_on:
       - 'postgres'
       - 'redis'
-      - 'opensearch'
+      - 'elasticsearch-oss'
     build:
       context: .
       dockerfile: Dockerfile.development
@@ -44,7 +48,7 @@ services:
     depends_on:
       - 'postgres'
       - 'redis'
-      - 'opensearch'
+      - 'elasticsearch-oss'
     build:
       context: .
       dockerfile: Dockerfile.development
@@ -59,35 +63,6 @@ services:
       DB_HOST: postgres
       DB_PORT: 5432
       DISABLE_SPRING: 1
-
-  opensearch:
-    image: opensearchproject/opensearch:2
-    container_name: opensearch
-    environment:
-      discovery.type: single-node
-      node.name: opensearch
-      # Disables Security plugin
-      DISABLE_SECURITY_PLUGIN: 'true'
-      OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
-    volumes:
-      - opensearch-data:/usr/share/opensearch/data
-    ports:
-      - 9200:9200
-      - 9600:9600
-
-  opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:2
-    container_name: opensearch-dashboards
-    ports:
-      - 5601:5601
-    expose:
-      - "5601"
-    environment:
-      # Disables security dashboards plugin in OpenSearch Dashboards
-      DISABLE_SECURITY_DASHBOARDS_PLUGIN: 'true'
-      OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
-    depends_on:
-      - opensearch
 
   magic:
     image: mageai/mageai:latest
@@ -137,6 +112,5 @@ services:
 volumes:
   cenabast-postgres:
     external: true
-  opensearch-data:
   redis:
   bundle_cache:

--- a/elasticsearch-compose.yml
+++ b/elasticsearch-compose.yml
@@ -1,0 +1,58 @@
+version: "2.2"
+
+services:
+  elasticsearch-oss:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+    container_name: elasticsearch-oss
+    restart: unless-stopped
+    hostname: elasticsearch
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - ${ES_PORT}:9200
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    environment:
+      ES_JAVA_OPTS: '-Xms4g -Xmx4g'
+      cluster.name: ${CLUSTER_NAME}
+      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD}
+      discovery.type: 'single-node'
+      node.master: 'true'
+      node.data: 'true'
+      node.ingest: 'true'
+      bootstrap.memory_lock: 'true'
+      network.host: 0.0.0.0
+
+  kibana-oss:
+    depends_on:
+      - 'elasticsearch-oss'
+    image: docker.elastic.co/kibana/kibana-oss:7.10.2
+    volumes:
+      - kibana-data:/usr/share/kibana/data
+    ports:
+      - ${KIBANA_PORT}:5601
+    environment:
+      DISABLE_SECURITY_PLUGIN: true
+      SERVERNAME: kibana
+      ELASTICSEARCH_HOSTS: http://elasticsearch-oss:9200
+      ELASTICSEARCH_USERNAME: kibana_system
+      ELASTICSEARCH_PASSWORD: ${KIBANA_PASSWORD}
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 120
+
+volumes:
+  certs:
+    driver: local
+  elasticsearch-data:
+    driver: local
+  kibana-data:
+    driver: local

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -5,7 +5,7 @@ require 'webdrivers'
 
 driver_hosts = Webdrivers::Common.subclasses.map { |driver| URI(driver.base_url).host }
 driver_hosts << 'codeclimate.com'
-driver_hosts << 'opensearch'
+driver_hosts << 'elasticsearch-oss'
 driver_hosts << 'postgres'
 driver_urls = Webdrivers::Common.subclasses.map(&:base_url)
 


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- https://linets.atlassian.net/browse/PE188-12

## Description

- Change from OpenSearch to Elasticsearch-oss (7.10.2) as the search engine in the Cenabast project.
- Tested in the development environment (reindex, Kibana dashboard, Tests passing)
- Updated README/env.example/other related docs.
- Correction of the pipeline (rspec Github action) to use Elasticsearch-oss.

- CVE exception was done for rack-cors gem.
No patch currently avaiable, gem is needed for the application.

## Checklist

Before you move on, make sure that:

- [x ] No unintended changes are included
- [x ] Spelling is correct
- [x ] There are tests covering new/changed functionality
- [x ] Rubocop style is passing, and Rspec tests are passing.
- [x ] Documentation has been written (Docs or code)
- [x ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x ] Proper labels assigned. Use `WIP` label to indicate that state
