### PR TITLE
[PE188-72] Correct toggle_receivers toggle_requesters for admin users

### DIFF
--- a/app/models/concerns/cenabast/spree/user/store_preference.rb
+++ b/app/models/concerns/cenabast/spree/user/store_preference.rb
@@ -49,18 +49,34 @@ module Cenabast
 
         # Toggles the receiver, the requester and store are based upon this entity
         def toggle_receiver(receiver)
+          return toggle_receiver_admin(receiver) if admin?
           return unless receivers.include? receiver
 
           self.current_receiver = receiver
           save
         end
 
+        # Toggle receiver without restrictions
+        # Use only for admin users
+        def toggle_receiver_admin(receiver)
+          self.current_receiver = receiver
+          save
+        end
+
         # Toggling this will change the receiver for the first available receiver of that requester
         def toggle_requester(requester)
+          return toggle_requester_admin(requester) if admin?
           return unless requesters.include? requester
           return unless matching_receivers_for_requester(requester).any?
 
           self.current_receiver = matching_receivers_for_requester(requester).first
+          save
+        end
+
+        # Toggle requester without restrictions
+        # Use only for admin users
+        def toggle_requester_admin(requester)
+          self.current_receiver = requester.receivers.first
           save
         end
 

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -125,6 +125,14 @@ RSpec.describe Spree::User, type: :model, search: true do
         expect(user.reload.current_receiver).to eq receiver
         expect(user.reload.current_receiver).not_to eq last_current_receiver
       end
+
+      it 'can toggle to any receiver if the user is admin' do
+        admin = create(:admin_user, run: '444444444', receivers: available_receivers)
+
+        new_receiver = non_available_receivers.sample
+        admin.toggle_receiver(new_receiver)
+        expect(admin.reload.current_receiver).to eq new_receiver
+      end
     end
 
     describe '#toggle_store' do
@@ -163,6 +171,19 @@ RSpec.describe Spree::User, type: :model, search: true do
         user.toggle_store(store)
 
         expect(user.current_store).to eq last_current_store
+      end
+
+      it 'can toggle to any receiver if the user is admin' do
+        not_allowed_stores = create_list(:store, 4)
+        receivers = stores.sample(4).map do |store|
+          create(:receiver, run:, store:)
+        end
+
+        admin = create(:admin_user, run: '444444444', receivers:)
+        store = not_allowed_stores.sample
+        admin.toggle_store(store)
+
+        expect(admin.reload.current_store).to eq store
       end
     end
   end


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- https://linets.atlassian.net/browse/PE188-72

## Description

- Fix behaviour of toggle_receiver/toggle_requester (Destinatario, Solicitante) for admin users
- Now they can toggle successfully without restrictions, if the have the admin permission.
- Related specs added

## Checklist

Before you move on, make sure that:

- [x ] No unintended changes are included
- [x ] Spelling is correct
- [x ] There are tests covering new/changed functionality
- [x ] Rubocop style is passing, and Rspec tests are passing.
- [x ] Documentation has been written (Docs or code)
- [x ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x ] Proper labels assigned. Use `WIP` label to indicate that state
