### PR TITLE
[PE188-72] Add distinct clause to has_many though relationship of users

### DIFF
--- a/app/models/concerns/cenabast/spree/user/store_preference.rb
+++ b/app/models/concerns/cenabast/spree/user/store_preference.rb
@@ -19,10 +19,10 @@ module Cenabast
           belongs_to :current_store, class_name: '::Spree::Store', optional: true
 
           has_many :receiver_users, class_name: 'Cenabast::Spree::ReceiverUser', dependent: :destroy
-          has_many :receivers, through: :receiver_users, class_name: 'Cenabast::Spree::Receiver'
-          has_many :requesters, through: :receivers, class_name: 'Cenabast::Spree::Requester'
+          has_many :receivers, -> { distinct }, through: :receiver_users, class_name: 'Cenabast::Spree::Receiver'
+          has_many :requesters, -> { distinct }, through: :receivers, class_name: 'Cenabast::Spree::Requester'
           has_many :company_users, class_name: 'Cenabast::Spree::CompanyUser', dependent: :destroy
-          has_many :companies, through: :company_users, class_name: 'Cenabast::Spree::Company'
+          has_many :companies, -> { distinct }, through: :company_users, class_name: 'Cenabast::Spree::Company'
 
           before_create :set_current_receiver
         end


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- [Link here all the related JIRA issues](https://linets.atlassian.net/browse/PE188-72)
- https://github.com/Departamento-TI/cenabast-tienda/issues/58

## Description

- Adds distinct clause to has_many relationships for Spree::User, so it avoids showing the same record more than once in the UI:
  - Cenabast::Spree::Company
  - Cenabast::Spree::Receiver
  - Cenabast::Spree::Requester
- Added related specs/tests

## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Rubocop style is passing, and Rspec tests are passing.
- [ ] Documentation has been written (Docs or code)
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
