### PR TITLE
Pe188 21 Product detail page layout

### DIFF
--- a/app/views/spree/products/_cart_form.html.erb
+++ b/app/views/spree/products/_cart_form.html.erb
@@ -70,7 +70,7 @@
 
       <hr>
       <div>
-        <div class="mb-5 mt-4 text-center text-md-left flex flex-row gap-1">
+        <div class="mb-5 mt-4 text-center text-md-left flex flex-row gap-8">
           <%= render 'spree/shared/quantity_select', input_name: :quantity %>
           <%= button_tag class: 'btn btn-primary w-100 text-uppercase font-weight-bold add-to-cart-button bg-primary-600 rounded-lg', id: 'add-to-cart-button', type: :submit, disabled: true do %>
             <%= Spree.t(:add_to_cart) %>

--- a/app/views/spree/products/_cart_form.html.erb
+++ b/app/views/spree/products/_cart_form.html.erb
@@ -70,13 +70,12 @@
 
       <hr>
       <div>
-        <div class="mb-5 mt-4 text-center text-md-left">
+        <div class="mb-5 mt-4 text-center text-md-left flex flex-row gap-1">
           <%= render 'spree/shared/quantity_select', input_name: :quantity %>
+          <%= button_tag class: 'btn btn-primary w-100 text-uppercase font-weight-bold add-to-cart-button bg-primary-600 rounded-lg', id: 'add-to-cart-button', type: :submit, disabled: true do %>
+            <%= Spree.t(:add_to_cart) %>
+          <% end %>
         </div>
-
-        <%= button_tag class: 'btn btn-primary w-100 text-uppercase font-weight-bold add-to-cart-button', id: 'add-to-cart-button', type: :submit, disabled: true do %>
-          <%= Spree.t(:add_to_cart) %>
-        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/spree/products/_cart_form.html.erb
+++ b/app/views/spree/products/_cart_form.html.erb
@@ -1,0 +1,83 @@
+<template class="availability-template availability-template-not-available-in-currency">
+  <%= render 'cart_form_availability_templates', type: 'not-available-in-currency' %>
+</template>
+
+<template class="availability-template availability-template-in-stock">
+  <%= render 'cart_form_availability_templates', type: 'in-stock' %>
+</template>
+
+<template class="availability-template availability-template-backorderable">
+  <%= render 'cart_form_availability_templates', type: 'backorderable' %>
+</template>
+
+<template class="availability-template availability-template-out-of-stock">
+  <%= render 'cart_form_availability_templates', type: 'out-of-stock' %>
+</template>
+
+<% is_product_available_in_currency = product_available_in_currency? %>
+<% default_variant = default_variant(@variants, @product) %>
+
+<%= form_for :order, html: {
+  id: 'add-to-cart-form',
+  class: 'add-to-cart-form',
+  'data-product-summary': @product_summary.to_json,
+  'data-variants': product_variants_matrix(is_product_available_in_currency),
+  'data-variant-change-trigger-identifier': variant_change_identifier
+} do |f| %>
+  <div id="inside-product-cart-form" data-hook="inside_product_cart_form">
+    <% if is_product_available_in_currency %>
+      <div id="product-price" class="mb-2 text-center text-md-left add-to-cart-form-price" data-hook="product_price">
+        <% if should_display_compare_at_price?(default_variant) %>
+          <span class="compare-at-price mr-3"><%= display_compare_at_price(default_variant) %></span>
+        <% end %>
+        <span class="price selling text-lg text-gray-500" content="<%= @product_price.to_d %>">
+          <%= display_price(default_variant) %>
+        </span>
+        <span content="<%= current_currency %>"></span>
+      </div>
+    <% end %>
+
+    <div class="text-center text-md-left add-to-cart-form-general-availability text-uppercase">
+      <%= Spree.t(:availability) %>:
+      <% if !is_product_available_in_currency %>
+        <%= render 'cart_form_availability_templates', type: 'not-available-in-currency' %>
+      <% elsif default_variant.in_stock? %>
+        <%= render 'cart_form_availability_templates', type: 'in-stock' %>
+      <% elsif default_variant.backorderable? %>
+        <%= render 'cart_form_availability_templates', type: 'backorderable' %>
+      <% else %>
+        <%= render 'cart_form_availability_templates', type: 'out-of-stock' %>
+      <% end %>
+    </div>
+
+    <% if @product.variants_and_option_values(current_currency).any? %>
+      <hr>
+      <ul id="product-variants" class="product-variants">
+        <% used_variants_options(@variants, @product).each_with_index do |option_type, index| %>
+          <li>
+            <% if color_option_type_name.present? && color_option_type_name == option_type[:name] %>
+              <%= render "color_option_type", option_type: option_type, index: index %>
+            <% else %>
+              <%= render "option_type", option_type: option_type, index: index %>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <% if is_product_available_in_currency && @product.can_supply? %>
+      <%= hidden_field_tag "variant_id", default_variant.id %>
+
+      <hr>
+      <div>
+        <div class="mb-5 mt-4 text-center text-md-left">
+          <%= render 'spree/shared/quantity_select', input_name: :quantity %>
+        </div>
+
+        <%= button_tag class: 'btn btn-primary w-100 text-uppercase font-weight-bold add-to-cart-button', id: 'add-to-cart-button', type: :submit, disabled: true do %>
+          <%= Spree.t(:add_to_cart) %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/spree/products/show.html.erb
+++ b/app/views/spree/products/show.html.erb
@@ -1,0 +1,71 @@
+<% @body_id = 'product-details' %>
+
+<div class="container">
+  <%= spree_breadcrumbs(@taxon, '', @product) %>
+</div>
+
+<% cache cache_key_for_product do %>
+  <div class="container pt-4 product-details">
+    <div class="row" data-hook="product_show">
+      <%= render partial: 'gallery' %>
+      <div class="col-12 col-md-5" data-hook="product_right_part">
+        <div id="product-description flex flex-row gap-2" data-hook="product_right_part_wrap">
+          <div id="vendor-name" class="text-sm text-blue-600">
+            <%= @product.vendor&.name || "Synthon Chile Ltda." %>
+          </div>
+          <h1 class="mt-3 mt-md-0 text-center text-md-left product-details-title">
+            <%= @product.name %>
+          </h1>
+          <div class="text-sm text-gray-400">
+            <%= @product.generic_product&.denomination || 'Everolimus 10mg CM' %>
+          </div>
+          <div class="text-sm text-gray-400">
+            SKU: <%= @product.sku %>
+          </div>
+
+          <div class="mt-7 mb-4">
+            <span>Sobre este producto</span>
+            <div class="grid grid-cols-3 gap-2 text-sm text-gray-400 mt-2">
+              <div class="flex flex-col gap-1">
+                <span class="text-gray-500 font-black">ID Mercado público</span>
+                <span><%= @product.generic_product&.code_onu || '5599-352-SE19' %></span>
+              </div>
+              <div class="flex flex-col gap-1 pl-3 border-l border-gray-300">
+                <span class="text-gray-500 font-black">Código ATC</span>
+                <span><%= @product.generic_product&.code_atc || 'L01H9L01XE10' %></span>
+              </div>
+              <div class="flex flex-col gap-1 pl-3 border-l border-gray-300">
+                <span class="text-gray-500 font-black">Denominación estándar</span>
+                <span><%= @product.generic_product&.standard_denomination || 'EVEROLIMUS' %></span>
+              </div>
+            </div>
+          </div>
+
+          <div id="cart-form" data-hook="cart_form">
+            <%= render 'cart_form', variant_change_identifier: 'productCarousel' %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="pb-4 pt-md-5 row" data-hook="product_description">
+      <div class="col-12 col-md-7 col-lg-6">
+        <%= render partial: 'description' %>
+      </div>
+    </div>
+
+    <div id="no-product-available" class="no-product-available-dropdown">
+      <%= render partial: 'spree/shared/no_product_available' %>
+    </div>
+
+    <%= render partial: 'gallery_modal' %>
+  </div>
+
+  <%= products_structured_data([@product]) %>
+
+  <%= render 'spree/shared/product_added_modal' %>
+<% end %>
+
+<div
+  data-related-products
+  data-related-products-id="<%= @product.slug %>"
+  data-related-products-enabled="<%= @product.respond_to?(:has_related_products?) %>" />

--- a/app/views/spree/products/show.html.erb
+++ b/app/views/spree/products/show.html.erb
@@ -11,32 +11,32 @@
       <div class="col-12 col-md-5" data-hook="product_right_part">
         <div id="product-description flex flex-row gap-2" data-hook="product_right_part_wrap">
           <div id="vendor-name" class="text-sm text-blue-600">
-            <%= @product.vendor&.name || "Synthon Chile Ltda." %>
+            <%= @product.vendor&.name %>
           </div>
           <h1 class="mt-3 mt-md-0 text-center text-md-left product-details-title">
             <%= @product.name %>
           </h1>
           <div class="text-sm text-gray-400">
-            <%= @product.generic_product&.denomination || 'Everolimus 10mg CM' %>
+            <%= @product.generic_product&.denomination %>
           </div>
           <div class="text-sm text-gray-400">
             SKU: <%= @product.sku %>
           </div>
 
           <div class="mt-7 mb-4">
-            <span>Sobre este producto</span>
+            <span><%= Spree.t('pdp.about_product') %></span>
             <div class="grid grid-cols-3 gap-2 text-sm text-gray-400 mt-2">
               <div class="flex flex-col gap-1">
-                <span class="text-gray-500 font-black">ID Mercado público</span>
-                <span><%= @product.generic_product&.code_onu || '5599-352-SE19' %></span>
+                <span class="text-gray-500 font-black"><%= Spree.t('pdp.mercado_publico_id') %></span>
+                <span><%= @product.contract&.mercado_publico_id %></span>
               </div>
               <div class="flex flex-col gap-1 pl-3 border-l border-gray-300">
-                <span class="text-gray-500 font-black">Código ATC</span>
-                <span><%= @product.generic_product&.code_atc || 'L01H9L01XE10' %></span>
+                <span class="text-gray-500 font-black"><%= Spree.t('pdp.atc_code') %></span>
+                <span><%= @product.generic_product&.code_atc %></span>
               </div>
               <div class="flex flex-col gap-1 pl-3 border-l border-gray-300">
-                <span class="text-gray-500 font-black">Denominación estándar</span>
-                <span><%= @product.generic_product&.standard_denomination || 'EVEROLIMUS' %></span>
+                <span class="text-gray-500 font-black"><%= Spree.t('pdp.standard_denomination') %></span>
+                <span><%= @product.generic_product&.standard_denomination %></span>
               </div>
             </div>
           </div>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -7,3 +7,11 @@ es:
     user_does_not_exist_on_system: 'Usuario no existe en sistema'
     user_does_not_has_valid_roles: 'Usuario no tiene roles validos'
     buyer_user_not_valid: 'Usuario comprador no valido'
+
+    pdp:
+      about_product: 'Sobre este producto'
+      mercado_publico_id: 'ID Mercado público'
+      atc_code: 'Código ATC'
+      standard_denomination: 'Denominación estándar'
+
+

--- a/db/seeds/002_stores.rb
+++ b/db/seeds/002_stores.rb
@@ -8,6 +8,7 @@ default_store.mail_from_address = 'no-reply@example.com'
 default_store.default_country = Spree::Country.find_by(iso: 'CL')
 default_store.default_currency = 'CLP'
 default_store.supported_locales = 'es'
+default_store.default_locale = 'es'
 default_store.save!
 
 intermediation_store = Spree::Store.find_or_initialize_by(code: 'spree-intermediation')
@@ -20,6 +21,7 @@ intermediation_store.mail_from_address = 'no-reply@example.com'
 intermediation_store.default_country = Spree::Country.find_by(iso: 'CL')
 intermediation_store.default_currency = 'CLP'
 intermediation_store.supported_locales = 'es'
+intermediation_store.default_locale = 'es'
 intermediation_store.save!
 
 # Destroy other stores that might exists

--- a/spec/factories/cenabast/spree/product_factory.rb
+++ b/spec/factories/cenabast/spree/product_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :cenabast_product, parent: :product do
+    contract { Cenabast::Spree::Contract.first || create(:contract) }
+    association :generic_product
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,3 +1,11 @@
 RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :component
+
+  config.before(:each, type: :system) do |example|
+    if example.metadata[:js]
+      driven_by :selenium_chrome_headless
+    else
+      driven_by :rack_test
+    end
+  end
 end

--- a/spec/system/product_page_spec.rb
+++ b/spec/system/product_page_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'Visiting Product Page', type: :system do
+  let(:user) { create(:user) }
+  let(:product) { create(:cenabast_product) }
+
+  before do
+    puts product.stores.pluck(:name)
+    act_as_logged_in(user)
+    visit "/products/#{product.slug}"
+  end
+
+  xit 'shows product' do
+    expect(page).to have_text(Spree.t('spree.pdp.about_product'))
+  end
+
+  xit 'should display product`s ATC code' do
+    expect(page).to have_text(product.generic_product.code_atc)
+  end
+end


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- [PE188-21](https://linets.atlassian.net/browse/PE188-21)

## Description

- Adapt spree product show to include cenabast product ZGEN attributes
- Default product data added to test the view

<img width="1608" alt="Captura de pantalla 2024-03-13 a la(s) 03 05 46" src="https://github.com/Departamento-TI/cenabast-tienda/assets/156840296/699f3698-04d0-495b-947d-51bda0bb3d0b">

## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Rubocop style is passing, and Rspec tests are passing.
- [ ] Documentation has been written (Docs or code)
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
