### PR TITLE
Disable Spree::Frontend http_cache_enabled config to always send http request to the server

### DIFF
--- a/config/initializers/spree_frontend.rb
+++ b/config/initializers/spree_frontend.rb
@@ -1,0 +1,5 @@
+Rails.application.config.after_initialize do
+  # Disable browser cache to always send http request to the server
+  # https://github.com/Departamento-TI/cenabast-tienda/issues/47#issuecomment-1995579584
+  Spree::Frontend::Config[:http_cache_enabled] = false
+end


### PR DESCRIPTION
… request to the server

## Link to Issue(s) in JIRA:
- https://linets.atlassian.net/browse/PE188-72
- https://github.com/Departamento-TI/cenabast-tienda/issues/47
## Description

- Disable Spree::Frontend http_cache_enabled config to always send http request to the server
- https://github.com/Departamento-TI/cenabast-tienda/issues/47#issuecomment-1995579584
- https://github.com/spree/spree_rails_frontend/pull/65/files#diff-59d24954a9c260a3460131e7206e2fa9bc9c450dcf57688b5fe5f557d7f598a2

## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- [x] There are tests covering new/changed functionality
- [x] Rubocop style is passing, and Rspec tests are passing.
- [x] Documentation has been written (Docs or code)
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x] Proper labels assigned. Use `WIP` label to indicate that state
