### PR TITLE
[PE188-72] Fix header fragment-cache issue

### DIFF
--- a/app/helpers/cenabast/spree/navigation_helper_decorator.rb
+++ b/app/helpers/cenabast/spree/navigation_helper_decorator.rb
@@ -1,0 +1,23 @@
+module Cenabast
+  module Spree
+    module NavigationHelperDecorator
+      # Redefine how the cache key is defined for menu sections of spree.
+      # Since presentation of header can change receiver/requester
+      def spree_menu_cache_key(section = 'header')
+        keys = base_cache_key + [
+          current_store.cache_key_with_version,
+          spree_menu(section)&.cache_key_with_version,
+          stores&.maximum(:updated_at),
+          spree_current_user&.cache_key_with_version,
+          spree_current_user&.current_receiver&.cache_key_with_version,
+          spree_current_user&.current_requester&.cache_key_with_version,
+          section
+        ]
+        Digest::MD5.hexdigest(keys.join('-'))
+      end
+    end
+  end
+end
+
+not_included = Spree::NavigationHelper.included_modules.exclude?(Cenabast::Spree::NavigationHelperDecorator)
+Spree::NavigationHelper.prepend Cenabast::Spree::NavigationHelperDecorator if not_included

--- a/app/models/concerns/cenabast/spree/user/store_preference.rb
+++ b/app/models/concerns/cenabast/spree/user/store_preference.rb
@@ -144,7 +144,7 @@ module Cenabast
         def set_current_receiver
           receiver = candidate_current_receiver
 
-          self[:current_receiver_id] ||= receiver&.id
+          self[:current_receiver_id] = receiver&.id
         end
       end
     end

--- a/config/locales/spree_auth_devise/es.yml
+++ b/config/locales/spree_auth_devise/es.yml
@@ -1,0 +1,53 @@
+# Data taken from spree_auth_devise project
+# https://github.com/spree/spree_auth_devise/blob/main/config/locales/es.yml
+
+---
+es:
+  devise:
+    confirmations:
+      confirmed: Su cuenta ha sido confirmada. Ahora está conectado.
+      send_instructions: Recibirá un email con instrucciones acerca de como confirmar su cuenta en pocos minutos.
+    failure:
+      inactive: Su cuenta no ha sido activada aún.
+      invalid: Dirección de correo o contraseña no válidos.
+      invalid_token: Token de autenticación no válido.
+      locked: Su cuenta está bloqueada.
+      timeout: 'Su sesión ha expirado, por favor conéctese de nuevo para continuar.'
+      unauthenticated: Necesita conectarse o registrarse para continuar.
+      unconfirmed: Necesita confirmar su cuenta para continuar.
+    mailer:
+      confirmation_instructions:
+        subject: Instrucciones de confirmación
+      reset_password_instructions:
+        subject: Instrucciones para restablecer la contraseña
+      unlock_instructions:
+        subject: Instrucciones de desbloqueo
+    oauth_callbacks:
+      failure: 'No es posible autorizarle desde %{kind} porque %{reason}.'
+      success: 'Cuenta autorizada correctamente desde %{kind}.'
+    unlocks:
+      send_instructions: Recibirá un email con instrucciones acerca de cómo desbloquear su cuenta en pocos minutos.
+      unlocked: Su cuenta ha sido desbloqueada correctamente. Ahora está conectado.
+    user_passwords:
+      spree_user:
+        cannot_be_blank: La contraseña no puede estar en blanco.
+        send_instructions: Recibirá un email con instrucciones acerca de como restaurar su contraseña en pocos minutos.
+        updated: Su contraseña ha sido cambiada correctamente. Ahora está conectado.
+    user_registrations:
+      destroyed: Hasta luego! Su cuenta ha sido cancelada correctamente. Esperamos volver a verle pronto.
+      inactive_signed_up: 'Ha sido registrado correctamente. Sin embargo, no se puede acceder porque su cuenta está %{reason}.'
+      signed_up: Bienvenido! Ha sido registrado correctamente.
+      updated: Su cuenta ha sido actualizada correctamente .
+    user_sessions:
+      signed_in: Conectado correctamente.
+      signed_out: Desconectado correctamente.
+      already_signed_out: Sesión finalizada.
+  errors:
+    messages:
+      already_confirmed: ya estaba confirmado
+      email_is_invalid: dirección de correo electrónico no puede estar en blanco
+      not_found: no encontrado
+      not_locked: no estaba bloqueado
+      not_saved:
+        one: '1 error impidió guardar este %{resource}:'
+        other: '%{count} errores impidieron guardar este %{resource}:'


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- https://linets.atlassian.net/browse/PE188-72
- https://github.com/Departamento-TI/cenabast-tienda/issues/47#issuecomment-1998601259

## Description

- Fix logic of how current_receiver_id is set. Now it forces the new value instead of using ||=
  - This will help on those cases where the user logs-in and doesnt has a valid receiver/requester to use
- Added decoration for spree_menu_cache_key helper method. Now it includes user/receiver/requester data, and thus allowing header to be refreshed when user changes receiver/requester/store under fragment cache enabled environments.
- Add missing spree_auth_devise translations for es locale

## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- [x] There are tests covering new/changed functionality
- [x] Rubocop style is passing, and Rspec tests are passing.
- [x] Documentation has been written (Docs or code)
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x] Proper labels assigned. Use `WIP` label to indicate that state
