### PR TITLE
[PE188-36] cart mockup components

### DIFF
--- a/app/assets/stylesheets/spree/frontend/cenabast/layout.scss
+++ b/app/assets/stylesheets/spree/frontend/cenabast/layout.scss
@@ -1,3 +1,4 @@
 body {
   padding-top: 0px;
+  background-color: rgb(242, 244, 247);
 }

--- a/app/components/common/button/base_component.rb
+++ b/app/components/common/button/base_component.rb
@@ -6,12 +6,14 @@ class Common::Button::BaseComponent < ApplicationComponent
   # =>  @param size select { choices: [sm, md, lg, xl, xxl] }
   # =>  @param hierarchy select { choices: [primary, secondary_color, secondary_gray, tertiary_color, tertiary_gray, link_color, link_gray] }
   # =>  @param destructive toggle
+  # =>  @param additional_styles text
   def initialize(button_params:)
     super
     @text = button_params[:text]
     @hierarchy = button_params[:hierarchy]
     @size = button_params[:size] || 'md'
     @destructive = button_params[:destructive]
+    @additional_styles = button_params[:additional_styles]
   end
 
   private
@@ -22,6 +24,7 @@ class Common::Button::BaseComponent < ApplicationComponent
     classes << base_classes
     classes << size_classes
     classes << hierarchy_classes
+    classes << @additional_styles
 
     classes.join(' ')
   end

--- a/app/components/common/layout/header_component.html.erb
+++ b/app/components/common/layout/header_component.html.erb
@@ -67,14 +67,14 @@
       <!-- Searchbar -->
       <div class="float-right pr-[26px] relative top-[-5px]" role='searchbar'>
         <form>
-            <label for="default-search" class="mb-2 text-sm font-medium text-gray-900 sr-only dark:text-white">Search</label>
+            <label for="default-search" class="mb-2 text-sm font-medium text-gray-900 sr-only">Search</label>
 
             <div class="absolute inset-y-0 start-0 flex items-center ps-3 pe-10 pointer-events-none">
-                <svg class="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                <svg class="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
                     <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
                 </svg>
             </div>
-            <input type="search" id="default-search" class="block w-full p-[10px] ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="Buscar producto" required>
+            <input type="search" id="default-search" class="block w-full p-[10px] ps-10 text-sm text-gray-900 border border-gray-300 rounded-lg bg-gray-50 focus:ring-blue-500 focus:border-blue-500" placeholder="Buscar producto" required>
         </form>
       </div>
     </div>

--- a/app/components/order/cart/line_item_component.html.erb
+++ b/app/components/order/cart/line_item_component.html.erb
@@ -1,24 +1,45 @@
-<%= fields_for "order[line_items_attributes][#{@id}]", @line_item do |item_form| %>
-  <tr class="border-b border-gray-200 dark:border-white/10">
+<%= fields_for "order[line_items_attributes][#{@index}]", @line_item do |item_form| %>
+  <tr class="shopping-cart-item border-b border-gray-200 dark:border-white/10">
+    <!-- Line item data -->
     <td class="whitespace-nowrap px-6 py-4 font-medium flex flex-row gap-4 text-gray-700 font-semibold">
       <div>
-        <%= image_tag @product_image_url, class: 'h-[64px] w-[64px] float-left', role: 'header-logo' %>
+        <%= link_to @product_url do %>
+          <%= image_tag @product_image_url, class: 'h-[64px] w-[64px] float-left', role: 'header-logo' %>
+        <% end %>
       </div>
       <div class="max-w-[400px]">
-        <p class="text-sm text-gray-500 mb-2"><%= @name %></p>
+        <p class="text-sm text-gray-500 mb-2"><%= link_to @name, @product_url %></p>
         <p class="text-sm text-primary-700"><%= @vendor_name %></p>
       </div>
     </td>
+
+    <!-- Line item price -->
     <td class="whitespace-nowrap px-6 py-4 font-semibold"><%= @price %></td>
+
+    <!-- Line item quantity picker -->
     <td class="whitespace-nowrap px-6 py-4 font-semibold">
       <div class="shopping-cart-item-quantity" data-hook="cart_item_quantity">
         <div class="d-flex align-items-center">
-          <%= button_tag '-', type: 'button', class: "border-right-0 shopping-cart-item-quantity-decrease-btn", data: { id: @id } %>
-          <%= item_form.number_field :quantity, value: @quantity, min: 0, class: "form-control text-center border-left-0 border-right-0 shopping-cart-item-quantity-input", size: 5, data: { id: @id }, aria: { label: Spree.t('cart_page.change_quantity') } %>
-          <%= button_tag '+', type: 'button', class: "border-left-0 shopping-cart-item-quantity-increase-btn", data: { id: @id } %>
+          <%= item_form.hidden_field :id, value: @id %>
+          <%= button_tag '-', type: 'button', class: "border-right-0 shopping-cart-item-quantity-decrease-btn", data: { id: @dom_id } %>
+          <%= item_form.number_field :quantity, value: @quantity, min: 0, class: "form-control text-center border-left-0 border-right-0 shopping-cart-item-quantity-input", size: 5, data: { id: @dom_id }, aria: { label: Spree.t('cart_page.change_quantity') } %>
+          <%= button_tag '+', type: 'button', class: "border-left-0 shopping-cart-item-quantity-increase-btn", data: { id: @dom_id } %>
         </div>
       </div>
     </td>
+
+    <!-- Line item total -->
     <td class="whitespace-nowrap px-6 py-4 font-semibold"><%= @total %></td>
+
+    <!-- Line item delete option -->
+    <td class="whitespace-nowrap px-6 py-4 font-semibold">
+      <div class="shopping-cart-item-delete" data-hook="cart_item_delete">
+        <%= link_to '#', class: 'delete', id: "delete_#{@dom_id}", data: { turbo: false, id: @dom_id }, aria: { label: Spree.t('cart_page.remove_from_cart') } do %>
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M13.3333 4.99984V4.33317C13.3333 3.39975 13.3333 2.93304 13.1517 2.57652C12.9919 2.26292 12.7369 2.00795 12.4233 1.84816C12.0668 1.6665 11.6001 1.6665 10.6667 1.6665H9.33333C8.39991 1.6665 7.9332 1.6665 7.57668 1.84816C7.26308 2.00795 7.00811 2.26292 6.84832 2.57652C6.66667 2.93304 6.66667 3.39975 6.66667 4.33317V4.99984M8.33333 9.58317V13.7498M11.6667 9.58317V13.7498M2.5 4.99984H17.5M15.8333 4.99984V14.3332C15.8333 15.7333 15.8333 16.4334 15.5608 16.9681C15.3212 17.4386 14.9387 17.821 14.4683 18.0607C13.9335 18.3332 13.2335 18.3332 11.8333 18.3332H8.16667C6.76654 18.3332 6.06647 18.3332 5.53169 18.0607C5.06129 17.821 4.67883 17.4386 4.43915 16.9681C4.16667 16.4334 4.16667 15.7333 4.16667 14.3332V4.99984" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        <% end %>
+      </div>
+    </td>
   </tr>
 <% end %>

--- a/app/components/order/cart/line_item_component.html.erb
+++ b/app/components/order/cart/line_item_component.html.erb
@@ -1,0 +1,24 @@
+<%= fields_for "order[line_items_attributes][#{@id}]", @line_item do |item_form| %>
+  <tr class="border-b border-gray-200 dark:border-white/10">
+    <td class="whitespace-nowrap px-6 py-4 font-medium flex flex-row gap-4 text-gray-700 font-semibold">
+      <div>
+        <%= image_tag @product_image_url, class: 'h-[64px] w-[64px] float-left', role: 'header-logo' %>
+      </div>
+      <div class="max-w-[400px]">
+        <p class="text-sm text-gray-500 mb-2"><%= @name %></p>
+        <p class="text-sm text-primary-700"><%= @vendor_name %></p>
+      </div>
+    </td>
+    <td class="whitespace-nowrap px-6 py-4 font-semibold"><%= @price %></td>
+    <td class="whitespace-nowrap px-6 py-4 font-semibold">
+      <div class="shopping-cart-item-quantity" data-hook="cart_item_quantity">
+        <div class="d-flex align-items-center">
+          <%= button_tag '-', type: 'button', class: "border-right-0 shopping-cart-item-quantity-decrease-btn", data: { id: @id } %>
+          <%= item_form.number_field :quantity, value: @quantity, min: 0, class: "form-control text-center border-left-0 border-right-0 shopping-cart-item-quantity-input", size: 5, data: { id: @id }, aria: { label: Spree.t('cart_page.change_quantity') } %>
+          <%= button_tag '+', type: 'button', class: "border-left-0 shopping-cart-item-quantity-increase-btn", data: { id: @id } %>
+        </div>
+      </div>
+    </td>
+    <td class="whitespace-nowrap px-6 py-4 font-semibold"><%= @total %></td>
+  </tr>
+<% end %>

--- a/app/components/order/cart/line_item_component.html.erb
+++ b/app/components/order/cart/line_item_component.html.erb
@@ -21,9 +21,9 @@
       <div class="shopping-cart-item-quantity" data-hook="cart_item_quantity">
         <div class="d-flex align-items-center">
           <%= item_form.hidden_field :id, value: @id %>
-          <%= button_tag '-', type: 'button', class: "border-right-0 shopping-cart-item-quantity-decrease-btn", data: { id: @dom_id } %>
+          <%= button_tag '-', type: 'button', class: "rounded-l-full border-right-1 border-gray-300 shopping-cart-item-quantity-decrease-btn", data: { id: @dom_id } %>
           <%= item_form.number_field :quantity, value: @quantity, min: 0, class: "form-control text-center border-left-0 border-right-0 shopping-cart-item-quantity-input", size: 5, data: { id: @dom_id }, role: 'line-item-quantity', aria: { label: Spree.t('cart_page.change_quantity') } %>
-          <%= button_tag '+', type: 'button', class: "border-left-0 shopping-cart-item-quantity-increase-btn", data: { id: @dom_id } %>
+          <%= button_tag '+', type: 'button', class: "rounded-r-full border-left-1 border-gray-300 shopping-cart-item-quantity-increase-btn", data: { id: @dom_id } %>
         </div>
       </div>
     </td>

--- a/app/components/order/cart/line_item_component.html.erb
+++ b/app/components/order/cart/line_item_component.html.erb
@@ -1,20 +1,20 @@
 <%= fields_for "order[line_items_attributes][#{@index}]", @line_item do |item_form| %>
-  <tr class="shopping-cart-item border-b border-gray-200 dark:border-white/10">
+  <tr class="shopping-cart-item border-b border-gray-200" role="line-item-container">
     <!-- Line item data -->
     <td class="whitespace-nowrap px-6 py-4 font-medium flex flex-row gap-4 text-gray-700 font-semibold">
       <div>
         <%= link_to @product_url do %>
-          <%= image_tag @product_image_url, class: 'h-[64px] w-[64px] float-left', role: 'header-logo' %>
+          <%= image_tag @product_image_url, class: 'h-[64px] w-[64px] float-left' %>
         <% end %>
       </div>
       <div class="max-w-[400px]">
-        <p class="text-sm text-gray-500 mb-2"><%= link_to @name, @product_url %></p>
-        <p class="text-sm text-primary-700"><%= @vendor_name %></p>
+        <p class="text-sm text-gray-500 mb-2" role="line-item-name"><%= link_to @name, @product_url %></p>
+        <p class="text-sm text-primary-700" role="line-item-vendor-name"><%= @vendor_name %></p>
       </div>
     </td>
 
     <!-- Line item price -->
-    <td class="whitespace-nowrap px-6 py-4 font-semibold"><%= @price %></td>
+    <td class="whitespace-nowrap px-6 py-4 font-semibold" role="line-item-price"><%= @price %></td>
 
     <!-- Line item quantity picker -->
     <td class="whitespace-nowrap px-6 py-4 font-semibold">
@@ -22,18 +22,18 @@
         <div class="d-flex align-items-center">
           <%= item_form.hidden_field :id, value: @id %>
           <%= button_tag '-', type: 'button', class: "border-right-0 shopping-cart-item-quantity-decrease-btn", data: { id: @dom_id } %>
-          <%= item_form.number_field :quantity, value: @quantity, min: 0, class: "form-control text-center border-left-0 border-right-0 shopping-cart-item-quantity-input", size: 5, data: { id: @dom_id }, aria: { label: Spree.t('cart_page.change_quantity') } %>
+          <%= item_form.number_field :quantity, value: @quantity, min: 0, class: "form-control text-center border-left-0 border-right-0 shopping-cart-item-quantity-input", size: 5, data: { id: @dom_id }, role: 'line-item-quantity', aria: { label: Spree.t('cart_page.change_quantity') } %>
           <%= button_tag '+', type: 'button', class: "border-left-0 shopping-cart-item-quantity-increase-btn", data: { id: @dom_id } %>
         </div>
       </div>
     </td>
 
     <!-- Line item total -->
-    <td class="whitespace-nowrap px-6 py-4 font-semibold"><%= @total %></td>
+    <td class="whitespace-nowrap px-6 py-4 font-semibold" role="line-item-total"><%= @total %></td>
 
     <!-- Line item delete option -->
     <td class="whitespace-nowrap px-6 py-4 font-semibold">
-      <div class="shopping-cart-item-delete" data-hook="cart_item_delete">
+      <div class="shopping-cart-item-delete" data-hook="cart_item_delete" role="line-item-delete">
         <%= link_to '#', class: 'delete', id: "delete_#{@dom_id}", data: { turbo: false, id: @dom_id }, aria: { label: Spree.t('cart_page.remove_from_cart') } do %>
           <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M13.3333 4.99984V4.33317C13.3333 3.39975 13.3333 2.93304 13.1517 2.57652C12.9919 2.26292 12.7369 2.00795 12.4233 1.84816C12.0668 1.6665 11.6001 1.6665 10.6667 1.6665H9.33333C8.39991 1.6665 7.9332 1.6665 7.57668 1.84816C7.26308 2.00795 7.00811 2.26292 6.84832 2.57652C6.66667 2.93304 6.66667 3.39975 6.66667 4.33317V4.99984M8.33333 9.58317V13.7498M11.6667 9.58317V13.7498M2.5 4.99984H17.5M15.8333 4.99984V14.3332C15.8333 15.7333 15.8333 16.4334 15.5608 16.9681C15.3212 17.4386 14.9387 17.821 14.4683 18.0607C13.9335 18.3332 13.2335 18.3332 11.8333 18.3332H8.16667C6.76654 18.3332 6.06647 18.3332 5.53169 18.0607C5.06129 17.821 4.67883 17.4386 4.43915 16.9681C4.16667 16.4334 4.16667 15.7333 4.16667 14.3332V4.99984" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/app/components/order/cart/line_item_component.rb
+++ b/app/components/order/cart/line_item_component.rb
@@ -3,6 +3,8 @@
 class Order::Cart::LineItemComponent < ApplicationComponent
   # @param line_item hash
   # => @param id number
+  # => @param dom_id number
+  # => @param index number
   # => @param price text
   # => @param quantity number
   # => @param total number
@@ -15,6 +17,8 @@ class Order::Cart::LineItemComponent < ApplicationComponent
     super
     @line_item = line_item
     @id = line_item[:id]
+    @dom_id = line_item[:dom_id]
+    @index = line_item[:index]
     @price = line_item[:price]
     @quantity = line_item[:quantity]
     @total = line_item[:total]

--- a/app/components/order/cart/line_item_component.rb
+++ b/app/components/order/cart/line_item_component.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Order::Cart::LineItemComponent < ApplicationComponent
+  # @param line_item hash
+  # => @param id number
+  # => @param price text
+  # => @param quantity number
+  # => @param total number
+  # => @param name text
+  # => @param vendor_name text
+  # => @param product_url text
+  # => @param product_image_url text
+
+  def initialize(line_item:)
+    super
+    @line_item = line_item
+    @id = line_item[:id]
+    @price = line_item[:price]
+    @quantity = line_item[:quantity]
+    @total = line_item[:total]
+    @name = line_item[:name]
+    @vendor_name = line_item[:vendor_name] || 'Hello'
+    @product_url = line_item[:product_url]
+    @product_image_url = line_item[:product_image_url]
+  end
+end

--- a/app/components/order/cart/list_component.html.erb
+++ b/app/components/order/cart/list_component.html.erb
@@ -1,43 +1,55 @@
-<% @line_items.group_by { |l| l[:vendor_name] }.each do |vendor_name, grouped_line_items| %>
-  <div class="item-cart-parent mx-auto p-0 maw-w-full max-h-full bg-white rounded-lg border border-gray-300 mb-[24px] shadow-sm">
-    <!-- Section header -->
-    <div class="border-b-2 border-gray-200 px-6 py-3 bg-primary-50 text-primary-700 toggle-cart">
-      <span class="font-semibold"><%= vendor_name %></span>
+<div class="bg-white rounded-lg border border-gray-300 flex flex-col">
 
-      <svg class="mx-2 w-[22px] h-[16px] item-cart-icon float-right transition-all" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" >
-        <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
-      </svg>
-      <span class="px-2 float-right rounded-lg border border-primary-200 text-xs">
-        <%= Spree.t(:articles_selected, count: grouped_line_items.count) %>
-      </span>
-    </div>
-
-    <!-- Table of line items -->
-    <div class="item-cart grid grid-rows-[1fr] transition-all">
-      <div class="overflow-hidden">
-        <table class="min-w-full text-left text-sm font-light">
-          <thead class="border-b border-gray-200 text-gray-700 text-xs">
-            <tr>
-              <th scope="col" class="w-3/5 px-6 py-3"><%= Spree.t(:product) %></th>
-              <th scope="col" class="px-6 py-3"><%= Spree.t(:price) %></th>
-              <th scope="col" class="px-6 py-3"><%= Spree.t(:quantity) %></th>
-              <th scope="col" class="px-6 py-3"><%= Spree.t(:total) %></th>
-              <th scope="col" class="px-6 py-3 w-[40px]"></th>
-            </tr>
-          </thead>
-          <tbody>
-            <% grouped_line_items.each do |line_item| %>
-              <%= render Order::Cart::LineItemComponent.new(
-                line_item: line_item
-              )
-              %>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-    </div>
+  <div class="p-[24px] pb-[16px]">
+    <span class="leading-6 text-gray-700 text-lg font-medium" role="list-title"><%= Spree.t(:cart) %></span>
   </div>
-<% end %>
+
+  <!-- Divider -->
+  <div class="border-b border-gray-200 my-2 h-[1px] w-auto"></div>
+
+  <div class="p-[24px] pb-[16px]">
+    <% @line_items.group_by { |l| l[:vendor_name] }.each do |vendor_name, grouped_line_items| %>
+      <div class="item-cart-parent mx-auto p-0 maw-w-full max-h-full bg-white rounded-lg border border-gray-300 mb-[24px] shadow-sm" role="list-vendor-line-items-container">
+        <!-- Section header -->
+        <div class="border-b-2 border-gray-200 px-6 py-3 bg-primary-50 text-primary-700 toggle-cart">
+          <span class="font-semibold"><%= vendor_name %></span>
+
+          <svg class="mx-2 w-[22px] h-[16px] item-cart-icon float-right transition-all" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" >
+            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+          </svg>
+          <span class="px-2 float-right rounded-lg border border-primary-200 text-xs">
+            <%= Spree.t(:articles_selected, count: grouped_line_items.count) %>
+          </span>
+        </div>
+
+        <!-- Table of line items -->
+        <div class="item-cart grid grid-rows-[1fr] transition-all">
+          <div class="overflow-hidden">
+            <table class="min-w-full text-left text-sm font-light">
+              <thead class="border-b border-gray-200 text-gray-700 text-xs" role="list-vendor-line-items-table-header">
+                <tr>
+                  <th scope="col" class="w-3/5 px-6 py-3"><%= Spree.t(:product) %></th>
+                  <th scope="col" class="px-6 py-3"><%= Spree.t(:price) %></th>
+                  <th scope="col" class="px-6 py-3"><%= Spree.t(:quantity) %></th>
+                  <th scope="col" class="px-6 py-3"><%= Spree.t(:total) %></th>
+                  <th scope="col" class="px-6 py-3 w-[40px]"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <% grouped_line_items.each do |line_item| %>
+                  <%= render Order::Cart::LineItemComponent.new(
+                    line_item: line_item
+                  )
+                  %>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
 
 <script>
   window.addEventListener('DOMContentLoaded', function() {

--- a/app/components/order/cart/list_component.html.erb
+++ b/app/components/order/cart/list_component.html.erb
@@ -26,7 +26,7 @@
         <div class="item-cart grid grid-rows-[1fr] transition-all">
           <div class="overflow-hidden">
             <table class="min-w-full text-left text-sm font-light">
-              <thead class="border-b border-gray-200 text-gray-700 text-xs" role="list-vendor-line-items-table-header">
+              <thead class="border-b border-gray-200 text-gray-500 text-xs" role="list-vendor-line-items-table-header">
                 <tr>
                   <th scope="col" class="w-3/5 px-6 py-3"><%= Spree.t(:product) %></th>
                   <th scope="col" class="px-6 py-3"><%= Spree.t(:price) %></th>

--- a/app/components/order/cart/list_component.html.erb
+++ b/app/components/order/cart/list_component.html.erb
@@ -1,23 +1,28 @@
 <% @line_items.group_by { |l| l[:vendor_name] }.each do |vendor_name, grouped_line_items| %>
   <div class="item-cart-parent mx-auto p-0 maw-w-full max-h-full bg-white rounded-lg border border-gray-300 mb-[24px] shadow-sm">
+    <!-- Section header -->
     <div class="border-b-2 border-gray-200 px-6 py-3 bg-primary-50 text-primary-700 toggle-cart">
       <span class="font-semibold"><%= vendor_name %></span>
 
       <svg class="mx-2 w-[22px] h-[16px] item-cart-icon float-right transition-all" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" >
         <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
       </svg>
-      <span class="px-2 float-right rounded-lg border border-primary-200 text-xs">5 artículos en total</span>
+      <span class="px-2 float-right rounded-lg border border-primary-200 text-xs">
+        <%= Spree.t(:articles_selected, count: grouped_line_items.count) %>
+      </span>
     </div>
 
+    <!-- Table of line items -->
     <div class="item-cart grid grid-rows-[1fr] transition-all">
       <div class="overflow-hidden">
         <table class="min-w-full text-left text-sm font-light">
           <thead class="border-b border-gray-200 text-gray-700 text-xs">
             <tr>
-              <th scope="col" class="w-3/5 px-6 py-3">Producto</th>
-              <th scope="col" class="px-6 py-3">Precio</th>
-              <th scope="col" class="px-6 py-3">Cantidad</th>
-              <th scope="col" class="px-6 py-3">Total</th>
+              <th scope="col" class="w-3/5 px-6 py-3"><%= Spree.t(:product) %></th>
+              <th scope="col" class="px-6 py-3"><%= Spree.t(:price) %></th>
+              <th scope="col" class="px-6 py-3"><%= Spree.t(:quantity) %></th>
+              <th scope="col" class="px-6 py-3"><%= Spree.t(:total) %></th>
+              <th scope="col" class="px-6 py-3 w-[40px]"></th>
             </tr>
           </thead>
           <tbody>

--- a/app/components/order/cart/list_component.html.erb
+++ b/app/components/order/cart/list_component.html.erb
@@ -1,0 +1,48 @@
+<% @line_items.group_by { |l| l[:vendor_name] }.each do |vendor_name, grouped_line_items| %>
+  <div class="item-cart-parent mx-auto p-0 maw-w-full max-h-full bg-white rounded-lg border border-gray-300 mb-[24px] shadow-sm">
+    <div class="border-b-2 border-gray-200 px-6 py-3 bg-primary-50 text-primary-700 toggle-cart">
+      <span class="font-semibold"><%= vendor_name %></span>
+
+      <svg class="mx-2 w-[22px] h-[16px] item-cart-icon float-right transition-all" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" >
+        <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+      </svg>
+      <span class="px-2 float-right rounded-lg border border-primary-200 text-xs">5 artículos en total</span>
+    </div>
+
+    <div class="item-cart grid grid-rows-[1fr] transition-all">
+      <div class="overflow-hidden">
+        <table class="min-w-full text-left text-sm font-light">
+          <thead class="border-b border-gray-200 text-gray-700 text-xs">
+            <tr>
+              <th scope="col" class="w-3/5 px-6 py-3">Producto</th>
+              <th scope="col" class="px-6 py-3">Precio</th>
+              <th scope="col" class="px-6 py-3">Cantidad</th>
+              <th scope="col" class="px-6 py-3">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% grouped_line_items.each do |line_item| %>
+              <%= render Order::Cart::LineItemComponent.new(
+                line_item: line_item
+              )
+              %>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<script>
+  window.addEventListener('DOMContentLoaded', function() {
+    let items = document.querySelectorAll('.toggle-cart')
+    items.forEach((item) => {
+      item.addEventListener('click', (e) => {
+        e.currentTarget.querySelector('.item-cart-icon').classList.toggle('rotate-180')
+        e.currentTarget.closest('.item-cart-parent').querySelector('.item-cart').classList.toggle('grid-rows-[1fr]')
+        e.currentTarget.closest('.item-cart-parent').querySelector('.item-cart').classList.toggle('grid-rows-[0fr]')
+      })
+    })
+  })
+</script>

--- a/app/components/order/cart/list_component.rb
+++ b/app/components/order/cart/list_component.rb
@@ -3,6 +3,8 @@
 class Order::Cart::ListComponent < ApplicationComponent
   # @param line_items array of hashes
   # => @param id number
+  # => @param dom_id number
+  # => @param index number
   # => @param price text
   # => @param quantity number
   # => @param total number

--- a/app/components/order/cart/list_component.rb
+++ b/app/components/order/cart/list_component.rb
@@ -17,10 +17,4 @@ class Order::Cart::ListComponent < ApplicationComponent
     super
     @line_items = line_items
   end
-
-  private
-
-  def before_render
-    @login_url = helpers.spree.spree_user_clave_unica_omniauth_authorize_path
-  end
 end

--- a/app/components/order/cart/list_component.rb
+++ b/app/components/order/cart/list_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Order::Cart::ListComponent < ApplicationComponent
+  # @param line_items array of hashes
+  # => @param id number
+  # => @param price text
+  # => @param quantity number
+  # => @param total number
+  # => @param name text
+  # => @param vendor_name text
+  # => @param product_url text
+  # => @param product_image_url text
+
+  def initialize(line_items:)
+    super
+    @line_items = line_items
+  end
+
+  private
+
+  def before_render
+    @login_url = helpers.spree.spree_user_clave_unica_omniauth_authorize_path
+  end
+end

--- a/app/components/order/cart/summary_component.html.erb
+++ b/app/components/order/cart/summary_component.html.erb
@@ -1,0 +1,37 @@
+<div class="item-cart-parent mx-auto p-0 maw-w-full max-h-full bg-white rounded-lg border border-gray-300 mb-[24px] shadow-sm font-medium">
+  <!-- Section header -->
+  <h1 class="px-2 py-4 text-gray-700 font-semibold text-center leading-8 text-lg"><%= Spree.t(:order_total) %></h1>
+
+  <% @stats_per_vendor.each do |stat_per_vendor| %>
+    <div class="m-3 rounded-lg border border-gray-300 p-3 flex flex-col">
+      <span class="font-semibold leading-6 text-primary-700 pb-2" role="summary-vendor-name"><%= stat_per_vendor[:vendor_name] || Spree.t(:no_laboratory) %></span>
+      <div>
+        <span class="float-left text-gray-500"><%= Spree.t(:subtotal) %></span>
+        <span class="float-right text-gray-700" role="summary-subtotal"><%= Spree::Money.new(stat_per_vendor[:subtotal], currency: 'CLP') %></span>
+      </div>
+    </div>
+  <% end %>
+
+  <!-- Divider -->
+  <div class="border-b border-gray-200 mt-12 mb-4 mx-4 h-[1px] w-auto"></div>
+
+  <div class="m-3 rounded-lg p-2 mb-4 text-gray-500 flex flex-row">
+    <span class="font-semibold"><%= Spree.t(:total) %></span>
+    <span class="ml-auto" role="summary-total"><%= Spree::Money.new(@total, currency: 'CLP') %></span>
+  </div>
+
+  <div class="m-3 rounded-lg p-2 mb-4 text-gray-500 flex flex-row">
+    <div class="flex-1">
+      <%= link_to @checkout_url do %>
+        <%= render Common::Button::BaseComponent.new(
+          button_params: {
+            text: Spree.t(:send_order),
+            size: 'lg',
+            hierarchy: 'primary',
+            additional_styles: 'w-full'
+          })
+        %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/order/cart/summary_component.rb
+++ b/app/components/order/cart/summary_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Order::Cart::SummaryComponent < ApplicationComponent
+  # @param total number
+  # @param stats_per_vendor array of hashes
+  # => @param vendor_name text
+  # => @param subtotal number
+  def initialize(total:, stats_per_vendor:)
+    super
+    @total = total
+    @stats_per_vendor = stats_per_vendor || []
+  end
+
+  private
+
+  def before_render
+    @checkout_url = helpers.spree.checkout_path
+  end
+end

--- a/app/controllers/cenabast/spree/orders_controller_decorator.rb
+++ b/app/controllers/cenabast/spree/orders_controller_decorator.rb
@@ -1,0 +1,22 @@
+module Cenabast
+  module Spree
+    module OrdersControllerDecorator
+      def self.prepended(base)
+        # Block every action, redirect to root path
+        base.before_action :set_stats_per_vendor, only: [:edit, :update]
+      end
+
+      private
+
+      def set_stats_per_vendor
+        @stats_per_vendor = Cenabast::Spree::Order::FindLineItemStatsGroupedByVendor.new(@order || current_order).call
+      end
+    end
+  end
+end
+
+def not_included
+  Spree::OrdersController.included_modules.exclude?(Cenabast::Spree::OrdersControllerDecorator)
+end
+
+Spree::OrdersController.prepend Cenabast::Spree::OrdersControllerDecorator if not_included

--- a/app/finders/cenabast/spree/order/find_line_item_stats_grouped_by_vendor.rb
+++ b/app/finders/cenabast/spree/order/find_line_item_stats_grouped_by_vendor.rb
@@ -23,10 +23,12 @@ module Cenabast
         private
 
         def query
+          subquery = "(#{query_inner.to_sql}) AS vendor_stats"
+
           ::Spree::Vendor.
             unscoped.
             reorder('').
-            from("(#{query_inner}) AS vendor_stats").
+            from(subquery).
             select('vendor_stats.subtotal, vendor_stats.name, vendor_stats.id')
         end
 
@@ -36,8 +38,7 @@ module Cenabast
             left_joins(variant: :vendor).
             reorder('').
             group('spree_variants.vendor_id, spree_vendors.name').
-            select('SUM(spree_line_items.price * spree_line_items.quantity) as subtotal, spree_vendors.name as name, spree_variants.vendor_id as id').
-            to_sql
+            select('SUM(spree_line_items.price * spree_line_items.quantity) as subtotal, spree_vendors.name as name, spree_variants.vendor_id as id')
         end
       end
     end

--- a/app/finders/cenabast/spree/order/find_line_item_stats_grouped_by_vendor.rb
+++ b/app/finders/cenabast/spree/order/find_line_item_stats_grouped_by_vendor.rb
@@ -1,0 +1,45 @@
+# Given an order, gets grouped line item stats by its vendor
+
+module Cenabast
+  module Spree
+    module Order
+      class FindLineItemStatsGroupedByVendor
+        attr_accessor :order
+
+        def initialize(order)
+          @order = order
+        end
+
+        def call
+          query.map do |record|
+            {
+              vendor_id: record.id,
+              vendor_name: record.name,
+              subtotal: record.subtotal
+            }
+          end
+        end
+
+        private
+
+        def query
+          ::Spree::Vendor.
+            unscoped.
+            reorder('').
+            from("(#{query_inner}) AS vendor_stats").
+            select('vendor_stats.subtotal, vendor_stats.name, vendor_stats.id')
+        end
+
+        def query_inner
+          order.
+            line_items.
+            left_joins(variant: :vendor).
+            reorder('').
+            group('spree_variants.vendor_id, spree_vendors.name').
+            select('SUM(spree_line_items.price * spree_line_items.quantity) as subtotal, spree_vendors.name as name, spree_variants.vendor_id as id').
+            to_sql
+        end
+      end
+    end
+  end
+end

--- a/app/views/spree/orders/_form.html.erb
+++ b/app/views/spree/orders/_form.html.erb
@@ -1,0 +1,30 @@
+<div id="no-product-available" class="no-product-available-dropdown hide-on-esc">
+  <%= render partial: 'spree/shared/no_product_available' %>
+</div>
+
+<%= render Order::Cart::ListComponent.new(
+  # test: order_form.object.line_items,
+  line_items: Spree::LineItem.all.each.map do |line_item|
+
+    {
+      id: line_item.id,
+      price: line_item.display_price,
+      quantity: line_item.quantity,
+      total: line_item.display_total,
+      name: line_item.name,
+      vendor_name: line_item&.vendor&.name || 'Laboratorio Saval',
+      product_url: spree.product_path(line_item.variant.product),
+      product_image_url: default_image_for_product_or_variant(line_item.variant) || image_url('noimage/backend-missing-image.svg')
+    }
+  end
+) %>
+
+<% if @order&.errors&.any? %>
+  <script>
+    window.addEventListener('DOMContentLoaded', function() {
+      document.getElementById('overlay').classList.add('shown');
+      document.getElementById('no-product-available').classList.add('shown');
+      window.scrollTo(0, 0);
+    })
+  </script>
+<% end %>

--- a/app/views/spree/orders/_form.html.erb
+++ b/app/views/spree/orders/_form.html.erb
@@ -3,16 +3,17 @@
 </div>
 
 <%= render Order::Cart::ListComponent.new(
-  # test: order_form.object.line_items,
-  line_items: Spree::LineItem.all.each.map do |line_item|
+  line_items: order_form.object.line_items.map.with_index do |line_item, index|
 
     {
       id: line_item.id,
+      dom_id: dom_id(line_item),
+      index:,
       price: line_item.display_price,
       quantity: line_item.quantity,
       total: line_item.display_total,
       name: line_item.name,
-      vendor_name: line_item&.vendor&.name || 'Laboratorio Saval',
+      vendor_name: line_item&.vendor&.name || Spree.t(:no_laboratory),
       product_url: spree.product_path(line_item.variant.product),
       product_image_url: default_image_for_product_or_variant(line_item.variant) || image_url('noimage/backend-missing-image.svg')
     }

--- a/app/views/spree/orders/_form.html.erb
+++ b/app/views/spree/orders/_form.html.erb
@@ -2,23 +2,34 @@
   <%= render partial: 'spree/shared/no_product_available' %>
 </div>
 
-<%= render Order::Cart::ListComponent.new(
-  line_items: order_form.object.line_items.map.with_index do |line_item, index|
+<div class="flex flex-row gap-4">
+  <div class="flex-1">
+    <%= render Order::Cart::ListComponent.new(
+      line_items: order_form.object.line_items.map.with_index do |line_item, index|
 
-    {
-      id: line_item.id,
-      dom_id: dom_id(line_item),
-      index:,
-      price: line_item.display_price,
-      quantity: line_item.quantity,
-      total: line_item.display_total,
-      name: line_item.name,
-      vendor_name: line_item&.vendor&.name || Spree.t(:no_laboratory),
-      product_url: spree.product_path(line_item.variant.product),
-      product_image_url: default_image_for_product_or_variant(line_item.variant) || image_url('noimage/backend-missing-image.svg')
-    }
-  end
-) %>
+        {
+          id: line_item.id,
+          dom_id: dom_id(line_item),
+          index:,
+          price: line_item.display_price,
+          quantity: line_item.quantity,
+          total: line_item.display_total,
+          name: line_item.name,
+          vendor_name: line_item&.vendor&.name || Spree.t(:no_laboratory),
+          product_url: spree.product_path(line_item.variant.product),
+          product_image_url: default_image_for_product_or_variant(line_item.variant) || image_url('noimage/backend-missing-image.svg')
+        }
+      end
+    ) %>
+  </div>
+
+  <div class="w-[300px]">
+    <%= render Order::Cart::SummaryComponent.new(
+      total: order_form.object.total,
+      stats_per_vendor: @stats_per_vendor
+    ) %>
+  </div>
+</div>
 
 <% if @order&.errors&.any? %>
   <script>

--- a/app/views/spree/orders/edit.html.erb
+++ b/app/views/spree/orders/edit.html.erb
@@ -3,7 +3,7 @@
 <div data-hook="cart_container" class="container shopping-cart">
   <%= render 'spree/shared/breadcrumbs', sections: [Spree.t(:account), Spree.t('cart_page.title')] %>
 
-  <h1 class="shopping-cart-header"><%= Spree.t('cart_page.header') %></h1>
+  <h1 class="shopping-cart-header mb-[-20px]"><%= Spree.t(:cart_summary) %></h1>
 
   <% if @order.line_items.empty? %>
     <div data-hook="empty_cart" class="shopping-cart-empty">

--- a/app/views/spree/orders/edit.html.erb
+++ b/app/views/spree/orders/edit.html.erb
@@ -1,0 +1,44 @@
+<% @body_id = 'cart' %>
+
+<div data-hook="cart_container" class="container shopping-cart">
+  <%= render 'spree/shared/breadcrumbs', sections: [Spree.t(:account), Spree.t('cart_page.title')] %>
+
+  <h1 class="shopping-cart-header"><%= Spree.t('cart_page.header') %></h1>
+
+  <% if @order.line_items.empty? %>
+    <div data-hook="empty_cart" class="shopping-cart-empty">
+      <div class="d-flex flex-column justify-content-between h-100">
+        <div class="d-flex flex-column align-items-center">
+          <%= icon(name: 'empty-cart',
+                   classes: 'shopping-cart-empty-image',
+                   width: 83,
+                   height: 83) %>
+
+          <p class="text-center shopping-cart-empty-info"><%= Spree.t('cart_page.empty_info').html_safe %></p>
+        </div>
+        <%= link_to Spree.t(:continue_shopping), spree.products_path, class: 'btn btn-primary text-uppercase font-weight-bold shopping-cart-empty-continue-link' %>
+      </div>
+    </div>
+  <% else %>
+    <div data-hook="outside_cart_form">
+      <%= form_for @order, url: spree.update_cart_path, html: { id: 'update-cart' } do |order_form| %>
+        <div data-hook="inside_cart_form">
+          <div data-hook="cart_items" class="shopping-cart-table">
+            <%= render partial: 'form', locals: { order_form: order_form } %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+
+<script>
+  window.addEventListener('DOMContentLoaded', function() {
+    Spree.current_order_token = "<%= @order.token %>"
+    <% if flash.any? %>
+      document.getElementById('overlay').classList.add('shown');
+      document.getElementById('no-product-available').classList.add('shown');
+      window.scrollTo(0, 0);
+    <% end %>
+  })
+</script>

--- a/app/views/spree/shared/_breadcrumbs.html.erb
+++ b/app/views/spree/shared/_breadcrumbs.html.erb
@@ -1,0 +1,29 @@
+<nav id="breadcrumbs" class="col-12 mt-1 mt-sm-3 mt-lg-4" aria-label="breadcrumbs">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">
+      <span>
+        <%= link_to Spree.t(:home), spree.root_path %>
+      </span>
+    </li>
+    <% if @taxon %>
+      <% @taxon.ancestors.where.not(parent_id: nil).each do |ancestor| %>
+        <li class="breadcrumb-item">
+          <%= ancestor.name %>
+        </li>
+      <% end %>
+      <li class="breadcrumb-item">
+        <%= @taxon.name %>
+      </li>
+    <% elsif sections %>
+      <% sections.each do |section| %>
+        <li class="breadcrumb-item">
+          <%= section %>
+        </li>
+      <% end %>
+    <% else %>
+      <li class="breadcrumb-item">
+        <%= current_page_name %>
+      </li>
+    <% end %>
+  </ol>
+</nav>

--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,0 +1,20 @@
+require 'money'
+
+# https://github.com/RubyMoney/money/issues/930#issuecomment-626241196
+# Set the locale backend to use currency data, not i18n information
+Money.locale_backend = :currency
+
+# Define a custom format for the currency
+# respecting commas for thousand separators and dots for decimal places
+Money::Currency.unregister('CLP')
+Money::Currency.register({
+  priority: 1,
+  iso_code: "CLP",
+  name: "Chilean Peso",
+  symbol: "$",
+  symbol_first: true,
+  subunit: "Peso",
+  subunit_to_unit: 1,
+  thousands_separator: ',',
+  decimal_mark: '.'
+})

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -15,6 +15,7 @@ es:
     no_laboratory: 'Sin Laboratorio'
     send_order: 'Enviar orden'
     order_total: 'Total de la orden'
+    cart_summary: 'Resumen de tu carrito'
     articles_selected:
       one: "%{count} artículo en total"
       other: "%{count} artículos en total"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -7,11 +7,12 @@ es:
     user_does_not_exist_on_system: 'Usuario no existe en sistema'
     user_does_not_has_valid_roles: 'Usuario no tiene roles validos'
     buyer_user_not_valid: 'Usuario comprador no valido'
-
     pdp:
       about_product: 'Sobre este producto'
       mercado_publico_id: 'ID Mercado público'
       atc_code: 'Código ATC'
       standard_denomination: 'Denominación estándar'
-
-
+    no_laboratory: 'Sin Laboratorio'
+    articles_selected:
+      one: "%{count} artículo en total"
+      other: "%{count} artículos en total"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -13,6 +13,8 @@ es:
       atc_code: 'Código ATC'
       standard_denomination: 'Denominación estándar'
     no_laboratory: 'Sin Laboratorio'
+    send_order: 'Enviar orden'
+    order_total: 'Total de la orden'
     articles_selected:
       one: "%{count} artículo en total"
       other: "%{count} artículos en total"

--- a/spec/components/order/cart/line_item_component_spec.rb
+++ b/spec/components/order/cart/line_item_component_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Order::Cart::LineItemComponent, type: :component do
+  it 'renders component' do
+    render_preview(:default, params: { name: 'Testing name', price: 123_123, quantity: 3 })
+
+    expect(page).to have_selector('[role="line-item-name"]')
+    expect(page).to have_selector('[role="line-item-vendor-name"]')
+    expect(page).to have_selector('[role="line-item-price"]')
+    expect(page).to have_selector('[role="line-item-total"]')
+    expect(page).to have_selector('[role="line-item-quantity"]')
+    expect(page).to have_selector('[role="line-item-delete"]')
+
+    title_container = page.find('[role="line-item-name"]')
+    expect(title_container).to have_content 'Testing name'
+
+    expect(page.find('[role="line-item-quantity"]').value).to eq '3'
+
+    quantity_container = page.find('[role="line-item-price"]')
+    expect(quantity_container).to have_content '$123.123'
+
+    expect(page).to have_link(href: '#')
+  end
+end

--- a/spec/components/order/cart/line_item_component_spec.rb
+++ b/spec/components/order/cart/line_item_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Order::Cart::LineItemComponent, type: :component do
     expect(page.find('[role="line-item-quantity"]').value).to eq '3'
 
     quantity_container = page.find('[role="line-item-price"]')
-    expect(quantity_container).to have_content '$123.123'
+    expect(quantity_container).to have_content '$123,123'
 
     expect(page).to have_link(href: '#')
   end

--- a/spec/components/order/cart/list_component_spec.rb
+++ b/spec/components/order/cart/list_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Order::Cart::ListComponent, type: :component do
+  it 'renders component' do
+    render_preview(:default)
+
+    expect(page).to have_selector('[role="list-title"]')
+    expect(page).to have_selector('[role="list-vendor-line-items-container"]', count: 4)
+    expect(page).to have_selector('[role="line-item-container"]', count: 5)
+
+    expect(page).to have_content Spree.t(:cart)
+  end
+end

--- a/spec/components/order/cart/summary_component_spec.rb
+++ b/spec/components/order/cart/summary_component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Order::Cart::SummaryComponent, type: :component do
+  it 'renders component' do
+    render_preview(:default)
+
+    expect(page).to have_selector('[role="summary-vendor-name"]', count: 3)
+    expect(page).to have_selector('[role="summary-subtotal"]', count: 3)
+    expect(page).to have_selector('[role="summary-total"]', count: 1)
+
+    expect(page).to have_content Spree.t(:order_total)
+
+    expect(page).to have_link(text: Spree.t(:send_order), href: spree.checkout_path)
+  end
+end

--- a/spec/components/previews/common/button/base_component_preview.rb
+++ b/spec/components/previews/common/button/base_component_preview.rb
@@ -3,12 +3,14 @@ class Common::Button::BaseComponentPreview < ViewComponent::Preview
   # @param size select { choices: [sm, md, lg, xl, xxl] }
   # @param hierarchy select { choices: [primary, secondary_color, secondary_gray, tertiary_color, tertiary_gray, link_color, link_gray] }
   # @param destructive toggle
-  def standard(text: 'Click me', size: 'md', hierarchy: 'primary', destructive: false)
+  # @param additional_styles text
+  def standard(text: 'Click me', size: 'md', hierarchy: 'primary', destructive: false, additional_styles: '')
     button_params = {
       text:,
       size:,
       hierarchy:,
-      destructive:
+      destructive:,
+      additional_styles:
     }
 
     render Common::Button::BaseComponent.new(button_params:)

--- a/spec/components/previews/order/cart/line_item_component_preview.rb
+++ b/spec/components/previews/order/cart/line_item_component_preview.rb
@@ -10,13 +10,15 @@ class Order::Cart::LineItemComponentPreview < ViewComponent::Preview
   def line_item
     {
       id: 1,
+      index: 1,
+      dom_id: 'test',
       price: Spree::Money.new(1200, currency: 'CLP'),
       quantity: 2,
       total: Spree::Money.new(2400, currency: 'CLP'),
       name: 'BACTEROL FORTE 160/800 CAJ 1000 CM',
       vendor_name: 'LABORATORIOS LAFI LTDA',
       product_url: '/products/test-url',
-      product_image_url: image_url('noimage/backend-missing-image.svg')
+      product_image_url: 'noimage/backend-missing-image.svg'
     }
   end
 end

--- a/spec/components/previews/order/cart/line_item_component_preview.rb
+++ b/spec/components/previews/order/cart/line_item_component_preview.rb
@@ -1,13 +1,23 @@
 # frozen_string_literal: true
 
 class Order::Cart::LineItemComponentPreview < ViewComponent::Preview
-  def default
+  # @param name text
+  # @param price number
+  # @param total number
+  # @param quantity number
+  def default(name: 'Line Item Test', price: 1200, total: 2400, quantity: 2)
+    line_item = build_line_item
+    line_item[:name] = name
+    line_item[:price] = Spree::Money.new(price, currency: 'CLP')
+    line_item[:total] = Spree::Money.new(total, currency: 'CLP')
+    line_item[:quantity] = quantity
+
     render Order::Cart::LineItemComponent.new(line_item:)
   end
 
   private
 
-  def line_item
+  def build_line_item
     {
       id: 1,
       index: 1,

--- a/spec/components/previews/order/cart/line_item_component_preview.rb
+++ b/spec/components/previews/order/cart/line_item_component_preview.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Order::Cart::LineItemComponentPreview < ViewComponent::Preview
+  def default
+    render Order::Cart::LineItemComponent.new(line_item:)
+  end
+
+  private
+
+  def line_item
+    {
+      id: 1,
+      price: Spree::Money.new(1200, currency: 'CLP'),
+      quantity: 2,
+      total: Spree::Money.new(2400, currency: 'CLP'),
+      name: 'BACTEROL FORTE 160/800 CAJ 1000 CM',
+      vendor_name: 'LABORATORIOS LAFI LTDA',
+      product_url: '/products/test-url',
+      product_image_url: image_url('noimage/backend-missing-image.svg')
+    }
+  end
+end

--- a/spec/components/previews/order/cart/list_component_preview.rb
+++ b/spec/components/previews/order/cart/list_component_preview.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class Order::Cart::ListComponentPreview < ViewComponent::Preview
+  def default
+    render Order::Cart::ListComponent.new(line_items:)
+  end
+
+  private
+
+  def line_items # rubocop:disable Metrics/MethodLength
+    [
+      {
+        id: 1,
+        price: Spree::Money.new(1200, currency: 'CLP'),
+        quantity: 2,
+        total: Spree::Money.new(2400, currency: 'CLP'),
+        name: 'BACTEROL FORTE 160/800 CAJ 1000 CM',
+        vendor_name: 'LABORATORIOS LAFI LTDA',
+        product_url: '/products/test-url',
+        product_image_url: 'noimage/backend-missing-image.svg'
+      },
+      {
+        id: 2,
+        price: Spree::Money.new(2400, currency: 'CLP'),
+        quantity: 3, total: Spree::Money.new(7200, currency: 'CLP'),
+        name: 'AGUJA P/EXTRACCION SANGR 21 G CAJ 100 UN',
+        vendor_name: 'MEDICAL FRONT SPA',
+        product_url: '/products/test-url',
+        product_image_url: 'noimage/backend-missing-image.svg'
+      },
+      {
+        id: 3,
+        price: Spree::Money.new(3600, currency: 'CLP'),
+        quantity: 4,
+        total: Spree::Money.new(14_400, currency: 'CLP'),
+        name: 'CLOPIVITAE 75 MG CAJ 28 CM REC',
+        vendor_name: 'MEDICAL FRONT SPA',
+        product_url: '/products/test-url',
+        product_image_url: 'noimage/backend-missing-image.svg'
+      },
+      {
+        id: 4,
+        price: Spree::Money.new(2000, currency: 'CLP'),
+        quantity: 4,
+        total: Spree::Money.new(8000, currency: 'CLP'),
+        name: 'CLOXACILINA 500 MG CAJ 12 CP',
+        vendor_name: 'ARAMA NATURAL PRODUCTS DISTRIBUIDOR',
+        product_url: '/products/test-url',
+        product_image_url: 'noimage/backend-missing-image.svg'
+      },
+      {
+        id: 5,
+        price: Spree::Money.new(21_000, currency: 'CLP'),
+        quantity: 10,
+        total: Spree::Money.new(210_000, currency: 'CLP'),
+        name: 'DACTINOMICINA 0,5 MG LIOF. CAJ 1 FAM',
+        vendor_name: 'BPH S.A.',
+        product_url: '/products/test-url',
+        product_image_url: 'noimage/backend-missing-image.svg'
+      }
+    ]
+  end
+end

--- a/spec/components/previews/order/cart/list_component_preview.rb
+++ b/spec/components/previews/order/cart/list_component_preview.rb
@@ -11,6 +11,8 @@ class Order::Cart::ListComponentPreview < ViewComponent::Preview
     [
       {
         id: 1,
+        index: 1,
+        dom_id: 'test1',
         price: Spree::Money.new(1200, currency: 'CLP'),
         quantity: 2,
         total: Spree::Money.new(2400, currency: 'CLP'),
@@ -21,6 +23,8 @@ class Order::Cart::ListComponentPreview < ViewComponent::Preview
       },
       {
         id: 2,
+        index: 2,
+        dom_id: 'test2',
         price: Spree::Money.new(2400, currency: 'CLP'),
         quantity: 3, total: Spree::Money.new(7200, currency: 'CLP'),
         name: 'AGUJA P/EXTRACCION SANGR 21 G CAJ 100 UN',
@@ -30,6 +34,8 @@ class Order::Cart::ListComponentPreview < ViewComponent::Preview
       },
       {
         id: 3,
+        index: 3,
+        dom_id: 'test3',
         price: Spree::Money.new(3600, currency: 'CLP'),
         quantity: 4,
         total: Spree::Money.new(14_400, currency: 'CLP'),
@@ -40,6 +46,8 @@ class Order::Cart::ListComponentPreview < ViewComponent::Preview
       },
       {
         id: 4,
+        index: 4,
+        dom_id: 'test4',
         price: Spree::Money.new(2000, currency: 'CLP'),
         quantity: 4,
         total: Spree::Money.new(8000, currency: 'CLP'),
@@ -50,6 +58,8 @@ class Order::Cart::ListComponentPreview < ViewComponent::Preview
       },
       {
         id: 5,
+        index: 5,
+        dom_id: 'test5',
         price: Spree::Money.new(21_000, currency: 'CLP'),
         quantity: 10,
         total: Spree::Money.new(210_000, currency: 'CLP'),

--- a/spec/components/previews/order/cart/summary_component_preview.rb
+++ b/spec/components/previews/order/cart/summary_component_preview.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Order::Cart::SummaryComponentPreview < ViewComponent::Preview
+  def default
+    render Order::Cart::SummaryComponent.new(total: 120_000, stats_per_vendor:)
+  end
+
+  private
+
+  def stats_per_vendor
+    [
+      {
+        vendor_id: 1,
+        vendor_name: 'BPH S.A.',
+        subtotal: 23_000
+      },
+      {
+        vendor_id: 2,
+        vendor_name: nil,
+        subtotal: 23_000
+      },
+      {
+        vendor_id: 3,
+        vendor_name: 'ARAMA NATURAL PRODUCTS DISTRIBUIDOR',
+        subtotal: 74_000
+      }
+    ]
+  end
+end

--- a/spec/finders/cenabast/spree/orders/find_line_item_stats_grouped_by_vendor_spec.rb
+++ b/spec/finders/cenabast/spree/orders/find_line_item_stats_grouped_by_vendor_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Cenabast::Spree::Order::FindLineItemStatsGroupedByVendor do
+  let(:order) { create(:order) }
+  let(:service) { described_class.new(order) }
+
+  describe '#call' do
+    it 'returns line item stats grouped by vendor' do
+      vendor1 = create(:vendor, name: Faker::Lorem.word)
+      vendor2 = create(:vendor, name: Faker::Lorem.word)
+
+      variant1 = create(:on_demand_master_variant, vendor: vendor1)
+      variant2 = create(:on_demand_master_variant, vendor: vendor2)
+      variant3 = create(:on_demand_master_variant, vendor: vendor2)
+
+      create(:line_item, order:, variant: variant1, price: 10, quantity: 2)
+      create(:line_item, order:, variant: variant2, price: 15, quantity: 3)
+      create(:line_item, order:, variant: variant3, price: 10, quantity: 1)
+
+      result = service.call
+
+      expect(result.length).to eq(2)
+
+      expect(result[0][:vendor_id]).to eq(vendor1.id)
+      expect(result[0][:vendor_name]).to eq(vendor1.name)
+      expect(result[0][:subtotal]).to eq(20)
+
+      expect(result[1][:vendor_id]).to eq(vendor2.id)
+      expect(result[1][:vendor_name]).to eq(vendor2.name)
+      expect(result[1][:subtotal]).to eq(55)
+    end
+  end
+end


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- https://linets.atlassian.net/browse/PE188-36

## Description

- Implemented cart_ related components into Order#edit view
  - ListComponent (list of line items)
  - LineItemComponent (each particular line item)
  - SummaryComponent (totalized order information)

![chrome_2024-03-20_16-42-59](https://github.com/Departamento-TI/cenabast-tienda/assets/156705333/496c08ad-f40a-4a3b-a801-76484b488ffb)

- Add logic to open/collapse each vendor section
- Re-mapped logic to change line item quantity
- Re-mapped logic to delete a certain line item
- Re-mapped logic to continue into checkout button
- Edited breadcrumbs to look more like how its laid on Figma
- Added related I18n translations
- Add logic to group line_items by its vendor field
- Add finder to obtain grouped stats by vendor considering a line_order (FindLineItemStatsGroupedByVendor)
- Add currency configuration to respect "," as thousand sepatators, and dots as decimal places for currency CLP
- Added related specs (components, finder class)
- Added previews for created components

⚠⚠⚠⚠⚠⚠
**Pending: "Validación por monto mínimo de compra" (not implemented in this PR)**
⚠⚠⚠⚠⚠⚠

## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- [x] There are tests covering new/changed functionality
- [x] Rubocop style is passing, and Rspec tests are passing.
- [x] Documentation has been written (Docs or code)
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x] Proper labels assigned. Use `WIP` label to indicate that state
