### PR TITLE
[PE188-118] Queue and model management for Sale orders sent to ERP

### DIFF
--- a/app/assets/stylesheets/spree/backend.css
+++ b/app/assets/stylesheets/spree/backend.css
@@ -1,0 +1,11 @@
+/*
+ * This is a manifest file that'll automatically include all the stylesheets available in this directory
+ * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
+ * the top of the compiled file, but it's generally better to create a new file per style scope.
+
+ *= require jquery-ui/autocomplete
+ *= require select2
+ *= require animate
+ *= require flatpickr
+ *= require spree/backend/spree_admin
+*/

--- a/app/assets/stylesheets/spree/backend/components/_cenabast_badges.scss
+++ b/app/assets/stylesheets/spree/backend/components/_cenabast_badges.scss
@@ -1,0 +1,16 @@
+// Additional badges for Cenabast statuses
+
+// Green
+.badge-sent {
+  @include badge-variant(theme-color('success'));
+}
+
+// Orange
+.badge-nullified {
+  @include badge-variant(theme-color('warning'));
+}
+
+// light
+.badge-initial {
+  @include badge-variant(theme-color('light'));
+}

--- a/app/assets/stylesheets/spree/backend/components/_cenabast_badges.scss
+++ b/app/assets/stylesheets/spree/backend/components/_cenabast_badges.scss
@@ -5,12 +5,21 @@
   @include badge-variant(theme-color('success'));
 }
 
+// Red
+.badge-with_errors {
+  @include badge-variant(theme-color('danger'));
+}
+
 // Orange
+.badge-partially_nullified,
 .badge-nullified {
   @include badge-variant(theme-color('warning'));
 }
 
 // light
+.badge-unknown,
+.badge-not_prepared,
+.badge-pending,
 .badge-initial {
   @include badge-variant(theme-color('light'));
 }

--- a/app/assets/stylesheets/spree/backend/spree_admin.css.scss
+++ b/app/assets/stylesheets/spree/backend/spree_admin.css.scss
@@ -1,0 +1,41 @@
+@import 'spree/backend/global/variables';
+@import 'spree/backend/global/mixins';
+
+@import 'bootstrap';
+@import 'glyphicons';
+@import 'spree/backend/shared/glyphicons_urls_fix';
+@import 'flag-icon';
+
+@import 'spree/backend/components/navbar';
+@import 'spree/backend/components/sidebar';
+@import 'spree/backend/components/tables';
+@import 'spree/backend/components/badges';
+@import 'spree/backend/components/cenabast_badges';
+@import 'spree/backend/components/main';
+@import 'spree/backend/components/page_header';
+@import 'spree/backend/components/icons';
+@import 'spree/backend/components/buttons';
+@import 'spree/backend/components/nav';
+@import 'spree/backend/components/filters';
+@import 'spree/backend/components/navigation';
+@import 'spree/backend/components/taxon_products_view';
+
+@import 'spree/backend/plugins/sweetalert2_custom';
+@import 'spree/backend/plugins/jquery_ui';
+@import 'spree/backend/plugins/flatpickr';
+@import 'spree/backend/plugins/select2_bootstrap4';
+@import 'spree/backend/plugins/select2_custom';
+@import 'spree/backend/plugins/tinymce_custom';
+@import 'spree/backend/plugins/nav_x';
+
+@import 'spree/backend/shared/base';
+@import 'spree/backend/shared/forms';
+@import 'spree/backend/shared/sortable_tree';
+
+@import 'spree/backend/views/menus';
+@import 'spree/backend/views/cms_pages';
+@import 'spree/backend/views/digitals';
+@import 'spree/backend/views/order_payments';
+@import 'spree/backend/views/product_properties';
+@import 'spree/backend/views/prototypes';
+@import 'spree/backend/views/taxonomies'

--- a/app/controllers/spree/admin/sale_orders_controller.rb
+++ b/app/controllers/spree/admin/sale_orders_controller.rb
@@ -1,0 +1,17 @@
+module Spree
+  module Admin
+    class SaleOrdersController < ResourceController
+      belongs_to 'spree/order', find_by: :number
+
+      def index
+        @sale_orders = @order.sale_orders.order(created_at: :asc)
+      end
+
+      private
+
+      def model_class
+        ::Cenabast::Spree::Erp::SaleOrder
+      end
+    end
+  end
+end

--- a/app/jobs/cenabast/spree/erp/send_sale_order_to_erp.rb
+++ b/app/jobs/cenabast/spree/erp/send_sale_order_to_erp.rb
@@ -1,0 +1,18 @@
+module Cenabast
+  module Spree
+    module Erp
+      class SendSaleOrderToErp < ::Spree::BaseJob
+        wait_proc = lambda do |executions|
+          intervals = [60, 300, 600, 1800]
+          intervals[executions - 1] || 3600
+        end
+        retry_on Exception, wait: wait_proc, attempts: 10
+        queue_as :erp
+
+        def perform(sale_order)
+          Cenabast::Spree::Erp::SaleOrders::SendToErp.new(sale_order).call
+        end
+      end
+    end
+  end
+end

--- a/app/models/cenabast/spree/admin/tabs/order_tabs_builder.rb
+++ b/app/models/cenabast/spree/admin/tabs/order_tabs_builder.rb
@@ -1,0 +1,41 @@
+module Cenabast
+  module Spree
+    module Admin
+      module Tabs
+        class OrderTabsBuilder
+          include ::Rails.application.routes.url_helpers
+          include ::Spree::Core::Engine.routes.url_helpers
+
+          def build
+            # Take base from OrderDefaultTabsBuilder
+            root = ::Spree::Admin::Tabs::OrderDefaultTabsBuilder.new.build
+
+            add_sale_orders_tab(root)
+
+            # Remove non relevant tabs
+            root.items.reject! { |it| it.key == 'payments' }
+            root.items.reject! { |it| it.key == 'customer_returns' }
+            root.items.reject! { |it| it.key == 'return_authorizations' }
+            root.items.reject! { |it| it.key == 'channel' }
+
+            root
+          end
+
+          private
+
+          def add_sale_orders_tab(root)
+            tab =
+              ::Spree::Admin::Tabs::TabBuilder.new('sale_orders', ->(resource) { admin_order_sale_orders_path(resource) }).
+              with_icon_key('file-earmark-spreadsheet.svg').
+              with_active_check.
+              with_update_ability_check.
+              with_data_hook('admin_order_tabs_sale_order_details').
+              build
+
+            root.add(tab)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/cenabast/spree/erp/by_product_injector.rb
+++ b/app/models/cenabast/spree/erp/by_product_injector.rb
@@ -3,10 +3,12 @@ module Cenabast
     module Erp
       # Class responsible for sending orders to the ERP per product.
       # This class follows Strategy pattern design
+      # Creates by each line item a different Erp SaleOrder, and sends them to the erp
       class ByProductInjector < Injector
         def send_order(order)
           order.line_items.each do |line_item|
-            Cenabast::Api::Erp::CreateOrder.new(order:, line_items: [line_item]).call
+            sale_order = Cenabast::Spree::Erp::SaleOrder.create_with_line_items!([line_item])
+            sale_order.send_to_erp!
           end
         end
       end

--- a/app/models/cenabast/spree/erp/by_vendor_injector.rb
+++ b/app/models/cenabast/spree/erp/by_vendor_injector.rb
@@ -2,20 +2,14 @@ module Cenabast
   module Spree
     module Erp
       # Class responsible for sending orders to the ERP.
-      # Group products by vendor and create an ERP order each one.
+      # Group products by vendor and create an ERP Sale order each one.
       class ByVendorInjector < Injector
         def send_order(order)
           Rails.logger.debug { "[#{self.class.name}] Order ERP injection started." }
           order.line_items.group_by { |line_item| line_item.variant.vendor }.each do |_vendor, grouped_line_items|
-            response = Cenabast::Api::Erp::CreateOrder.new(order:, line_items: grouped_line_items).call
-            process_response(response)
+            sale_order = Cenabast::Spree::Erp::SaleOrder.create_with_line_items!(grouped_line_items)
+            sale_order.send_to_erp!
           end
-        end
-
-        private
-
-        def process_response(response)
-          Rails.logger.info "[#{self.class.name}] Processing ERP order creation response #{response}"
         end
       end
     end

--- a/app/models/cenabast/spree/erp/detail_line.rb
+++ b/app/models/cenabast/spree/erp/detail_line.rb
@@ -1,0 +1,6 @@
+class Cenabast::Spree::Erp::DetailLine < Spree::Base
+  self.table_name = 'cenabast_spree_erp_detail_lines'
+
+  belongs_to :sale_order, class_name: 'Cenabast::Spree::Erp::SaleOrder', optional: false
+  belongs_to :line_item, class_name: '::Spree::LineItem', optional: false
+end

--- a/app/models/cenabast/spree/erp/injector.rb
+++ b/app/models/cenabast/spree/erp/injector.rb
@@ -5,12 +5,6 @@ module Cenabast
         def send_order(order)
           raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
         end
-
-        private
-
-        def process_response(response)
-          raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
-        end
       end
     end
   end

--- a/app/models/cenabast/spree/erp/sale_order.rb
+++ b/app/models/cenabast/spree/erp/sale_order.rb
@@ -1,0 +1,40 @@
+class Cenabast::Spree::Erp::SaleOrder < Spree::Base
+  self.table_name = 'cenabast_spree_erp_sale_orders'
+
+  # Use Spree number generator related modules
+  # to set the number parameter
+  include ::Spree::Core::NumberGenerator.new(prefix: 'S')
+  include ::Spree::NumberIdentifier
+  include ::Spree::NumberAsParam
+
+  belongs_to :order, class_name: '::Spree::Order', optional: false
+  has_many :detail_lines, class_name: 'Cenabast::Spree::Erp::DetailLine', dependent: :destroy
+  has_many :line_items, -> { distinct }, through: :detail_lines, class_name: '::Spree::LineItem'
+
+  enum status: {
+    initial: 0,
+    sent: 1,
+    failed: 2,
+    nullified: 3
+  }
+
+  def self.create_with_line_items!(line_items)
+    return unless line_items.any?
+    return unless (order = line_items&.first&.order)
+
+    detail_lines = line_items.map do |line_item|
+      Cenabast::Spree::Erp::DetailLine.new(
+        line_item:
+      )
+    end
+    sale_order = new(order:, detail_lines:)
+    sale_order.save!
+
+    sale_order
+  end
+
+  def send_to_erp!
+    # Send to erp using job
+    Cenabast::Spree::Erp::SendSaleOrderToErp.perform_later(self)
+  end
+end

--- a/app/models/cenabast/spree/order_decorator.rb
+++ b/app/models/cenabast/spree/order_decorator.rb
@@ -3,6 +3,7 @@ module Cenabast
     module OrderDecorator
       def self.prepended(base)
         base.belongs_to :receiver, class_name: 'Cenabast::Spree::Receiver', optional: false
+        base.has_many :sale_orders, class_name: 'Cenabast::Spree::Erp::SaleOrder', dependent: :destroy
 
         base.state_machine.after_transition to: :complete, do: :inject_to_erp!
       end

--- a/app/models/cenabast/spree/order_decorator.rb
+++ b/app/models/cenabast/spree/order_decorator.rb
@@ -2,8 +2,9 @@ module Cenabast
   module Spree
     module OrderDecorator
       def self.prepended(base)
+        base.include Cenabast::Spree::HasSaleOrders
+
         base.belongs_to :receiver, class_name: 'Cenabast::Spree::Receiver', optional: false
-        base.has_many :sale_orders, class_name: 'Cenabast::Spree::Erp::SaleOrder', dependent: :destroy
 
         base.state_machine.after_transition to: :complete, do: :inject_to_erp!
       end

--- a/app/models/concerns/cenabast/spree/has_sale_orders.rb
+++ b/app/models/concerns/cenabast/spree/has_sale_orders.rb
@@ -1,0 +1,60 @@
+module Cenabast
+  module Spree
+    module HasSaleOrders
+      extend ActiveSupport::Concern
+
+      included do
+        has_many :sale_orders, class_name: 'Cenabast::Spree::Erp::SaleOrder', dependent: :destroy
+      end
+
+      def erp_send_status
+        # check every rule in order, return status sym
+        # if condition is met
+        erp_send_status_rules.each do |rule|
+          return rule[0] if send(rule[1])
+        end
+
+        :unknown
+      end
+
+      private
+
+      def erp_send_status_rules
+        [
+          [:not_prepared, :erp_send_status_not_prepared?],
+          [:pending, :erp_send_status_pending?],
+          [:with_errors, :erp_send_status_failed?],
+          [:partially_nullified, :erp_send_status_partially_nullified?],
+          [:nullified, :erp_send_status_nullified?],
+          [:sent, :erp_send_status_sent?],
+        ]
+      end
+
+      def erp_send_status_not_prepared?
+        sale_orders.none?
+      end
+
+      def erp_send_status_pending?
+        sale_orders.any?(&:initial?) &&
+          sale_orders.none?(&:failed?) &&
+          sale_orders.none?(&:nullified?)
+      end
+
+      def erp_send_status_failed?
+        sale_orders.any?(&:failed?)
+      end
+
+      def erp_send_status_partially_nullified?
+        sale_orders.any?(&:nullified?) && !sale_orders.all?(&:nullified?)
+      end
+
+      def erp_send_status_nullified?
+        sale_orders.all?(&:nullified?)
+      end
+
+      def erp_send_status_sent?
+        sale_orders.all?(&:sent?)
+      end
+    end
+  end
+end

--- a/app/services/cenabast/spree/erp/sale_orders/send_to_erp.rb
+++ b/app/services/cenabast/spree/erp/sale_orders/send_to_erp.rb
@@ -1,0 +1,71 @@
+module Cenabast
+  module Spree
+    module Erp
+      module SaleOrders
+        class SendToErp
+          attr_accessor :sale_order
+
+          delegate :order, :line_items, :number, to: :sale_order
+
+          def initialize(sale_order)
+            @sale_order = sale_order
+          end
+
+          def call
+            Rails.logger.info { "[#{self.class.name}][#{number}] Sending SaleOrder #{number} to ERP" }
+
+            if response&.dig(:success)
+              Rails.logger.info { "[#{self.class.name}][#{number}] Successfull response, will save information" }
+              save_success_information!
+            else
+              process_failure!
+            end
+          rescue StandardError => e
+            Rails.logger.error("[#{self.class.name}] Send to Erp process failed: #{e.message}")
+            Rails.logger.debug { "[#{self.class.name}] #{e.backtrace.join("\n")}" }
+            process_failure!
+          end
+
+          private
+
+          def response
+            @response ||= do_request
+          end
+
+          def save_success_information!
+            return unless (content = response&.dig(:response_content))
+
+            content = content.first if content.instance_of? Array
+            content = content&.deep_symbolize_keys
+
+            sale_order.update!(
+              status: :sent,
+              sent_at: Time.now.in_time_zone,
+              erp_pedido_id: content[:pedidoId],
+              erp_pv_id: content[:pedidoVentaId],
+              erp_fecha_creacion: content[:fechaCreacion]
+            )
+          end
+
+          def process_failure!
+            msg = <<-MSG
+              [#{self.class.name}][#{number}] Unsuccessful response
+              or caught exception, will mark sale order as failed and throw exception
+            MSG
+            Rails.logger.info msg.squish
+            sale_order.failed!
+
+            raise StandardError, "[#{self.class.name}]#{number} ERP response not successful!"
+          end
+
+          def do_request
+            Cenabast::Api::Erp::CreateOrder.new(
+              order:,
+              line_items:
+            ).call
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/spree/admin/orders/index.html.erb
+++ b/app/views/spree/admin/orders/index.html.erb
@@ -1,0 +1,120 @@
+<% content_for :page_title do %>
+  <%= plural_resource_name(Spree::Order) %>
+<% end %>
+
+<% content_for :page_actions do %>
+  <% orders_actions.items.each do |action| %>
+    <% next unless action.available?(current_ability) %>
+    <%= button_link_to(
+      Spree.t(action.label_translation_key),
+      action.url,
+      class: action.classes,
+      icon: action.icon_key,
+      id: action.id
+    ) %>
+  <% end %>
+<% end %>
+
+<% content_for :page_tabs do %>
+  <li class="nav-item">
+    <%= link_to Spree.t('admin.orders.all'),
+      spree.admin_orders_path(q: { completed_at_not_null: 1 }),
+      class: "nav-link #{'active' if params[:q][:payment_state_not_eq].blank? && params[:q][:shipment_state_not_eq].blank?}" %>
+  </li>
+<% end if @show_only_completed %>
+
+<%= render "search" if @orders.any? || params[:q].present? %>
+
+<% if @orders.any? %>
+
+<div data-nav-x-wrapper>
+  <div data-nav-x-container>
+    <table class="table border rounded" id="listing_orders" data-hook data-nav-x-content>
+      <thead class="text-muted">
+        <tr data-hook="admin_orders_index_headers">
+          <th><%= I18n.t(:number, scope: 'activerecord.attributes.spree/order') %></th>
+          <% if @show_only_completed %>
+            <th><%= sort_link @search, :completed_at,   I18n.t(:completed_at, scope: 'activerecord.attributes.spree/order') %></th>
+          <% else %>
+            <th><%= sort_link @search, :created_at,     I18n.t(:created_at, scope: 'activerecord.attributes.spree/order') %></th>
+          <% end %>
+          <th><%= I18n.t(:considered_risky, scope: 'activerecord.attributes.spree/order') %></th>
+          <th><%= Spree.t(:erp_send_status) %></th>
+           <% if Spree::Order.checkout_step_names.include?(:delivery) %>
+            <th><%= I18n.t(:shipment_state, scope: 'activerecord.attributes.spree/order') %></th>
+           <% end %>
+          <th><%= I18n.t(:email, scope: 'activerecord.attributes.spree/order') %></th>
+          <th><%= sort_link @search, :total,            I18n.t(:total, scope: 'activerecord.attributes.spree/order') %></th>
+          <th data-hook="admin_orders_index_header_actions" class="actions"></th>
+        </tr>
+      </thead>
+      <tbody>
+      <% @orders.each do |order| %>
+        <tr data-hook="admin_orders_index_rows" class="state-<%= order.state.downcase %> <%= cycle('odd', 'even') %>">
+          <td><%= link_to order.number, edit_admin_order_path(order) %></td>
+          <td>
+            <%= order_time(@show_only_completed ? order.completed_at : order.created_at) %>
+          </td>
+          <td>
+            <span class="badge badge-pill badge-<%= order.considered_risky ? 'considered_risky' : 'considered_safe' %>">
+              <%= order.considered_risky ? Spree.t("risky") : Spree.t("safe") %>
+            </span>
+          </td>
+          <td class="no-wrap">
+            <span class="state badge badge-pill badge-<%= order.erp_send_status %> text-capitalize" id='item_send_state'>
+              <%= Spree.t("order.erp_send_statuses.#{order.erp_send_status}") %>
+            </span>
+          </td>
+          <% if Spree::Order.checkout_step_names.include?(:delivery) %>
+            <td class="no-wrap">
+              <% if order.shipment_state %>
+                <span class="badge badge-pill badge-<%= order.shipment_state %>"><%= Spree.t("shipment_states.#{order.shipment_state}") %></span>
+                <span class="filterable js-add-filter" data-ransack-field="q_shipment_state_eq" data-ransack-value="<%= order.shipment_state %>">
+                  <%= svg_icon name: "filter.svg", width: '14', height: '14' %>
+                </span>
+              <% end %>
+            </td>
+          <% end %>
+          <td class="no-wrap">
+            <% if order.user %>
+              <%= link_to order.email, edit_admin_user_path(order.user) %>
+            <% else %>
+              <%= mail_to order.email %>
+            <% end %>
+            <% if order.user || order.email %>
+              <span class="filterable js-add-filter" data-ransack-field="q_email_cont" data-ransack-value="<%= order.email %>">
+                <%= svg_icon name: "filter.svg", width: '14', height: '14' %>
+              </span>
+            <% end %>
+          </td>
+          <td><%= order.display_total.to_html %></td>
+          <td class='actions' data-hook="admin_orders_index_row_actions">
+            <span class="d-flex justify-content-end">
+              <%= link_to_edit_url edit_admin_order_path(order), title: "admin_edit_#{dom_id(order)}", no_text: true if can?(:edit, order) %>
+            </span>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+  <button class="nav-x_Advancer nav-x_Advancer_Left" type="button">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z" />
+    </svg>
+  </button>
+
+  <button class="nav-x_Advancer nav-x_Advancer_Right" type="button">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z" />
+    </svg>
+  </button>
+</div>
+<% else %>
+  <div class="text-center no-objects-found m-5">
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Spree::Order)) %><% if can? :create, Spree::Order %>,
+    <%= link_to(Spree.t(:add_one), new_admin_order_url) %>!<% end %>
+  </div>
+<% end %>
+
+<%= render 'spree/admin/shared/index_table_options', collection: @orders, simple: true if @orders.any? %>

--- a/app/views/spree/admin/sale_orders/_sale_order.html.erb
+++ b/app/views/spree/admin/sale_orders/_sale_order.html.erb
@@ -1,0 +1,64 @@
+<div id="<%= "sale_order_#{sale_order.id}" %>" data-hook="admin_sale_order_form" class="card mb-3">
+  <div class="card-header sale-order no-borderb" data-hook="sale-order">
+    <div class="flex flex-col">
+      <div class="flex flex-row justify-between">
+        <div class="d-inline-block">
+          <h5 class="flex-wrap align-items-center card-title mb-0 h6">
+            <span class="sale_order-number"><%= sale_order.number %></span>
+            -
+            <span class="sale-order-status">Estado:</span>
+            <span class="badge badge-pill badge-<%= sale_order.status %>">
+              <%= Spree.t("sale_order_statuses.#{sale_order.status}") %>
+            </span>
+          </h5>
+        </div>
+
+        <div class="float-right">
+          <% if sale_order.sent? && can?(:edit, sale_order) %>
+            <!-- Placeholder, here it should be placed the nullify button action -->
+            <!-- More info on how link_to_edit works can be seen in spree_backend navigation_helper.rb -->
+            <%= link_to_edit(sale_order) %>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="flex flex-row">
+        <strong><%= Spree.t(:erp_pedido_id) %>:</strong>
+        <span><%= sale_order.erp_pedido_id || '--' %></span>
+      </div>
+
+      <div class="flex flex-row">
+        <strong><%= Spree.t(:erp_pv_id) %>:</strong>
+        <span><%= sale_order.erp_pv_id || '--' %></span>
+      </div>
+
+      <div class="flex flex-row">
+        <strong><%= Spree.t(:sent_at) %>:</strong>
+        <span><%= sale_order.sent_at || '--' %></span>
+      </div>
+
+      <div class="flex flex-row">
+        <strong><%= Spree.t(:nullified_at) %>:</strong>
+        <span><%= sale_order.nullified_at || '--' %></span>
+      </div>
+    </div>
+  </div>
+
+  <div class="table-responsive bg-white">
+    <table class="table stock-contents" data-hook="stock-contents">
+      <thead class="text-muted">
+        <tr>
+          <th colspan="2"><%= Spree.t(:item_description) %></th>
+          <th width="15%"><%= Spree.t(:vendor) %></th>
+          <th width="15%" class="text-center"><%= Spree.t(:price) %></th>
+          <th width="15%" class="text-center"><%= Spree.t(:quantity) %></th>
+          <th width="15%" class="text-center"><%= Spree.t(:total) %></th>
+        </tr>
+      </thead>
+
+      <tbody data-sale-order-number="<%= sale_order.number %>">
+        <%= render 'sale_order_detail', sale_order: sale_order %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/spree/admin/sale_orders/_sale_order_detail.html.erb
+++ b/app/views/spree/admin/sale_orders/_sale_order_detail.html.erb
@@ -1,0 +1,30 @@
+<% sale_order.line_items.each do |line_item| %>
+  <tr class="sale-order-line-item" data-item-quantity="<%= line_item.quantity %>">
+    <td class="item-image image text-center">
+      <%= link_to small_image(line_item.variant), edit_admin_product_path(line_item.variant.product) %>
+    </td>
+
+    <td class="item-name">
+      <%= link_to line_item.variant.product.name, edit_admin_product_path(line_item.variant.product) %>
+      <br>
+      <%= "(#{line_item.variant.options_text})" if line_item.variant.options_text.present? %>
+      <% if line_item.variant.sku.present? %>
+        <strong><%= Spree.t(:sku) %>:</strong> <%= line_item.variant.sku %>
+      <% end %>
+    </td>
+
+    <td class="item-vendor">
+      <%= line_item&.variant&.vendor&.name || Spree.t(:no_laboratory) %>
+    </td>
+
+    <td class="item-price text-center"><%= line_item.single_money.to_html %></td>
+
+    <td class="item-qty-show text-center">
+      <%= line_item.quantity %>
+    </td>
+
+    <td class="item-total text-center">
+      <%= line_item_shipment_price(line_item, line_item.quantity) %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/spree/admin/sale_orders/index.html.erb
+++ b/app/views/spree/admin/sale_orders/index.html.erb
@@ -1,0 +1,16 @@
+<%= render partial: 'spree/admin/shared/order_tabs', locals: { current: :sale_orders } %>
+
+<% if @sale_orders.present? %>
+  <%= render partial: "sale_order", collection: @sale_orders %>
+<% else %>
+  <div class="text-center m-5">
+    <%= Spree.t(:no_resource_found, resource: plural_resource_name(Cenabast::Spree::Erp::SaleOrder)) %>
+  </div>
+<% end %>
+
+<script>
+  var order_number = '<%= @order.number %>';
+  var order_id = '<%= @order.id %>';
+</script>
+
+<%= render partial: 'spree/admin/shared/order_summary' %>

--- a/app/views/spree/admin/shared/_order_summary.html.erb
+++ b/app/views/spree/admin/shared/_order_summary.html.erb
@@ -1,0 +1,131 @@
+<% content_for(:sidebar) do %>
+  <div class="card mb-3" id="order_tab_summary">
+    <div class="card-header">
+      <h3 class="card-title mb-0 h6"><%= Spree.t(:summary) %></h3>
+    </div>
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small><%= Spree.t(:status) %></small>
+        <span class="state badge badge-pill badge-<%= @order.state %> badge-pill text-capitalize" id="order_status">
+          <%= Spree.t(@order.state, scope: :order_state) %>
+        </span>
+      </li>
+
+      <% if @order.shipment_state.present? %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <small><%= Spree.t(:shipment) %></small>
+          <span class="state badge badge-pill badge-<%= @order.shipment_state %> badge-pill text-capitalize" id="shipment_status">
+            <%= Spree.t(@order.shipment_state, scope: :shipment_states, default: [:missing, "none"]) %>
+          </span>
+        </li>
+      <% end %>
+
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small data-hook='admin_order_tab_erp_send_state_title'><%= Spree.t(:erp_send_status) %></small>
+        <span class="state badge badge-pill badge-<%= @order.erp_send_status %> text-capitalize" id='item_send_state'>
+          <%= Spree.t("order.erp_send_statuses.#{@order.erp_send_status}") %>
+        </span>
+      </li>
+
+      <% if @order.payment_state.present? %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <small><%= Spree.t(:payment) %></small>
+          <span class="state badge badge-pill badge-<%= @order.payment_state %> badge-pill text-capitalize" id="payment_status">
+            <%= Spree.t(@order.payment_state, scope: :payment_states, default: [:missing, "none"]) %>
+          </span>
+        </li>
+      <% end %>
+
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small data-hook='admin_order_tab_channel_title'><%= Spree.t(:channel) %></small>
+        <span class="state badge badge-pill text-capitalize" id='order_channel'>
+          <%= @order.channel %>
+        </span>
+      </li>
+
+      <% if @order.completed? %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <small data-hook='admin_order_tab_date_completed_title'><%= Spree.t(:date_completed) %></small>
+          <span class="text-right small font-weight-bold" id='date_complete'>
+            <%= pretty_time(@order.completed_at) %>
+          </span>
+        </li>
+      <% end %>
+
+      <% if @order.approved? %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <small><%= Spree.t(:approved_at) %></small>
+          <span class="text-right small font-weight-bold">
+            <%= pretty_time(@order.approved_at) %>
+          </span>
+        </li>
+        <% if @order.approver.present? %>
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <small><%= Spree.t(:approver) %></small>
+            <span class="text-right small font-weight-bold">
+              <%= link_to @order.approver.email, spree.admin_users_path(@order.approver) %>
+            </span>
+          </li>
+        <% end %>
+      <% end %>
+
+      <% if @order.canceled? && @order.canceled_at %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <small><%= Spree.t(:canceled_at) %></small>
+          <span class="text-right small font-weight-bold">
+            <%= pretty_time(@order.canceled_at) %>
+          </span>
+        </li>
+        <% if @order.canceler.present? %>
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <small><%= Spree.t(:canceler) %></small>
+            <span class="text-right small font-weight-bold">
+              <%= link_to @order.canceler.email, spree.admin_users_path(@order.canceler) %>
+            </span>
+          </li>
+        <% end %>
+      <% end %>
+
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small data-hook='admin_order_tab_subtotal_title'><%= Spree.t(:subtotal) %></small>
+        <span class="state badge badge-pill text-capitalize" id='item_total'>
+          <%= @order.display_item_total.to_html %>
+        </span>
+      </li>
+
+      <% if @order.checkout_steps.include?("delivery") && @order.ship_total > 0 %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <small data-hook='admin_order_tab_ship_total_title'><%= Spree.t(:ship_total) %></small>
+          <span class="state badge badge-pill text-capitalize" id='ship_total'>
+            <%= @order.display_ship_total.to_html %>
+          </span>
+        </li>
+      <% end %>
+
+      <% if @order.included_tax_total != 0 %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <small data-hook='admin_order_tab_included_tax_title'><%= Spree.t(:tax_included) %></small>
+          <span class="state badge badge-pill text-capitalize" id='included_tax_total'>
+            <%= @order.display_included_tax_total.to_html %>
+          </span>
+        </li>
+      <% end %>
+
+      <% if @order.additional_tax_total != 0 %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <small data-hook='admin_order_tab_additional_tax_title'><%= Spree.t(:tax) %></small>
+          <span class="state badge badge-pill text-capitalize" id='additional_tax_total'>
+            <%= @order.display_additional_tax_total.to_html %>
+          </span>
+        </li>
+      <% end %>
+
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <small data-hook='admin_order_tab_total_title'><%= Spree.t(:total) %></small>
+        <span class="state badge badge-pill badge-primary text-capitalize" id='order_total'>
+          <%= @order.display_total.to_html %>
+        </span>
+      </li>
+    </ul>
+  </div>
+<% end %>

--- a/config/initializers/spree_backend.rb
+++ b/config/initializers/spree_backend.rb
@@ -1,0 +1,7 @@
+Rails.application.config.after_initialize do
+  Rails.application.reload_routes!
+
+  # Set up tabs for order in backoffice view
+  order_tabs = Cenabast::Spree::Admin::Tabs::OrderTabsBuilder.new.build
+  Rails.application.config.spree_backend.tabs[:order] = order_tabs
+end

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -71,7 +71,22 @@ es:
     erp_pedido_id: 'ERP Id de Pedido'
     erp_pv_id: 'ERP ID de PV'
     erp_fecha_creacion: 'ERP Fecha de creación'
+    erp_send_status: 'Estado de envio a ERP'
     state_changes: 'Cambios de estado'
     sale_orders: 'ERP Pedidos de Venta'
     sent_at: 'Fecha Envío'
     nullified_at: 'Fecha Anulación'
+    search_by: 'Buscar por'
+    search_order_number: 'Numero de Orden'
+    admin:
+      orders:
+        all: 'Todas las ordenes'
+    order:
+      erp_send_statuses:
+        unknown: 'Desconocido'
+        not_prepared: 'No preparado'
+        pending: 'Pendiente de envio'
+        with_errors: 'Con errores'
+        partially_nullified: 'Parcialmente nulo'
+        nullified: 'Anulado'
+        sent: 'Enviado'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -63,3 +63,15 @@ es:
     stock_validator:
       not_enough_stock: 'No hay suficiente stock para el producto "%{sku}".'
       information_retrieve_error: 'Error al validar stock del producto "%{sku}".'
+    sale_order_statuses:
+      initial: 'Inicial'
+      sent: 'Enviado'
+      failed: 'Fallido'
+      nullified: 'Anulado'
+    erp_pedido_id: 'ERP Id de Pedido'
+    erp_pv_id: 'ERP ID de PV'
+    erp_fecha_creacion: 'ERP Fecha de creación'
+    state_changes: 'Cambios de estado'
+    sale_orders: 'ERP Pedidos de Venta'
+    sent_at: 'Fecha Envío'
+    nullified_at: 'Fecha Anulación'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   # Spree User routes
   instance_eval(File.read(Rails.root.join("config/routes/spree_user_routes.rb")))
 
+  # Spree admin routes
+  instance_eval(File.read(Rails.root.join("config/routes/spree_admin_routes.rb")))
+
   # sidekiq web UI
   require 'sidekiq/web'
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|

--- a/config/routes/spree_admin_routes.rb
+++ b/config/routes/spree_admin_routes.rb
@@ -1,0 +1,8 @@
+Spree::Core::Engine.add_routes do
+  namespace :admin, path: Spree.admin_path do
+    resources :orders, except: [:show] do
+      resources :sale_orders,
+        only: [:index, :edit]
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,3 +7,4 @@
   - active_storage_analysis
   - spree_stock_location_stock_items
   - spree_webhooks
+  - erp

--- a/db/migrate/20240410153232_create_cenabast_spree_erp_sale_orders.rb
+++ b/db/migrate/20240410153232_create_cenabast_spree_erp_sale_orders.rb
@@ -1,0 +1,19 @@
+class CreateCenabastSpreeErpSaleOrders < ActiveRecord::Migration[7.1]
+  def change
+    create_table :cenabast_spree_erp_sale_orders do |t|
+      t.string :number
+      t.integer :status, default: 0, null: false
+
+      t.string :erp_pedido_id
+      t.string :erp_pv_id
+      t.string :erp_fecha_creacion
+
+      t.datetime :sent_at, null: true
+      t.datetime :nullified_at, null: true
+
+      t.references :order, null: false, foreign_key: { to_table: :spree_orders }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240410153239_create_cenabast_spree_erp_detail_lines.rb
+++ b/db/migrate/20240410153239_create_cenabast_spree_erp_detail_lines.rb
@@ -1,0 +1,11 @@
+class CreateCenabastSpreeErpDetailLines < ActiveRecord::Migration[7.1]
+  def change
+    create_table :cenabast_spree_erp_detail_lines do |t|
+
+      t.references :sale_order, null: false, foreign_key: { to_table: :cenabast_spree_erp_sale_orders }
+      t.references :line_item, null: false, foreign_key: { to_table: :spree_line_items }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_03_185427) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_10_153239) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -100,6 +100,29 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_185427) do
     t.integer "quantity", default: 0, null: false
     t.index ["code"], name: "index_cenabast_spree_contracts_on_code", unique: true
     t.index ["product_id"], name: "index_cenabast_spree_contracts_on_product_id"
+  end
+
+  create_table "cenabast_spree_erp_detail_lines", force: :cascade do |t|
+    t.bigint "sale_order_id", null: false
+    t.bigint "line_item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["line_item_id"], name: "index_cenabast_spree_erp_detail_lines_on_line_item_id"
+    t.index ["sale_order_id"], name: "index_cenabast_spree_erp_detail_lines_on_sale_order_id"
+  end
+
+  create_table "cenabast_spree_erp_sale_orders", force: :cascade do |t|
+    t.string "number"
+    t.integer "status", default: 0, null: false
+    t.string "erp_pedido_id"
+    t.string "erp_pv_id"
+    t.string "erp_fecha_creacion"
+    t.datetime "sent_at"
+    t.datetime "nullified_at"
+    t.bigint "order_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_cenabast_spree_erp_sale_orders_on_order_id"
   end
 
   create_table "cenabast_spree_generic_products", force: :cascade do |t|
@@ -1795,6 +1818,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_185427) do
   add_foreign_key "cenabast_spree_company_users", "cenabast_spree_companies", column: "company_id"
   add_foreign_key "cenabast_spree_company_users", "spree_users", column: "user_id"
   add_foreign_key "cenabast_spree_contracts", "spree_products", column: "product_id"
+  add_foreign_key "cenabast_spree_erp_detail_lines", "cenabast_spree_erp_sale_orders", column: "sale_order_id"
+  add_foreign_key "cenabast_spree_erp_detail_lines", "spree_line_items", column: "line_item_id"
+  add_foreign_key "cenabast_spree_erp_sale_orders", "spree_orders", column: "order_id"
   add_foreign_key "cenabast_spree_receiver_users", "cenabast_spree_receivers", column: "receiver_id"
   add_foreign_key "cenabast_spree_receiver_users", "spree_users", column: "user_id"
   add_foreign_key "cenabast_spree_receivers", "cenabast_spree_requesters", column: "requester_id"

--- a/spec/factories/cenabast/spree/erp/detail_line.rb
+++ b/spec/factories/cenabast/spree/erp/detail_line.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :erp_detail_line, class: 'Cenabast::Spree::Erp::DetailLine' do
+    sale_order { Cenabast::Spree::Erp::SaleOrder || create(:erp_sale_order) }
+    line_item { Spree::LineItem.first || create(:line_item) }
+  end
+end

--- a/spec/factories/cenabast/spree/erp/sale_order.rb
+++ b/spec/factories/cenabast/spree/erp/sale_order.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :erp_sale_order, class: 'Cenabast::Spree::Erp::SaleOrder' do
+    status { 'initial' }
+    order { Spree::Order.first || create(:order) }
+  end
+end

--- a/spec/models/cenabast/spree/erp/detail_line_spec.rb
+++ b/spec/models/cenabast/spree/erp/detail_line_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe Cenabast::Spree::Erp::DetailLine, type: :model do
+  describe 'Associations' do
+    it { is_expected.to belong_to(:sale_order).class_name('Cenabast::Spree::Erp::SaleOrder').optional(false) }
+    it { is_expected.to belong_to(:line_item).class_name('Spree::LineItem').optional(false) }
+  end
+end

--- a/spec/models/cenabast/spree/erp/sale_order_spec.rb
+++ b/spec/models/cenabast/spree/erp/sale_order_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe Cenabast::Spree::Erp::SaleOrder, type: :model do
+  describe 'Associations' do
+    it { is_expected.to have_many(:detail_lines).class_name('Cenabast::Spree::Erp::DetailLine').dependent(:destroy) }
+    it { is_expected.to have_many(:line_items).through(:detail_lines).class_name('Spree::LineItem') }
+  end
+
+  describe 'Enums' do
+    it { is_expected.to define_enum_for(:status).with_values(initial: 0, sent: 1, failed: 2, nullified: 3) }
+  end
+
+  describe '.create_with_line_items!' do
+    let(:order) { create(:order) }
+    let(:line_items) { create_list(:line_item, rand(3..5), order:) }
+
+    it 'can create with a list_of_line_items' do
+      expect do
+        subject.class.create_with_line_items!(line_items)
+      end.to change(Cenabast::Spree::Erp::SaleOrder, :count).by(1)
+
+      sale_order = Cenabast::Spree::Erp::SaleOrder.last
+      expect(sale_order.line_items.count).to eq(line_items.count)
+      expect(sale_order.order).to eq(order)
+    end
+  end
+
+  describe '#send_to_erp!' do
+    before do
+      allow(Cenabast::Spree::Erp::SendSaleOrderToErp).to receive(:perform_later).and_return(
+        double(true)
+      )
+    end
+
+    it 'calls SendSaleOrderToErp perform_later' do
+      subject.send_to_erp!
+      expect(Cenabast::Spree::Erp::SendSaleOrderToErp).to have_received(:perform_later).with(subject)
+    end
+  end
+end

--- a/spec/services/cenabast/spree/erp/sale_orders/send_to_erp_spec.rb
+++ b/spec/services/cenabast/spree/erp/sale_orders/send_to_erp_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Cenabast::Spree::Erp::SaleOrders::SendToErp do
+  let(:requester) { create(:requester, run: '26.896.041-4') }
+  let(:receiver) { create(:receiver, requester:, run: '23.328.386-K') }
+  let(:order) { create(:order, receiver:, selected_delivery_port: 'ABC') }
+  let(:sale_order) { create(:erp_sale_order, order:) }
+  let(:vendors) { create_list(:vendor, 3) }
+
+  before(:each) do
+    vendors.each.with_index do |vendor, index|
+      contract = create(:contract, sale_order: "111#{index}", mercado_publico_oc: '123')
+      product = create(:product_in_stock, contract:, vendor:, sku: "4422#{index}")
+      line_item = create(:line_item, order:, product:, quantity: 2)
+      create(:erp_detail_line, sale_order:, line_item:)
+    end
+  end
+
+  describe '#call - valid response' do
+    before(:each) do
+      VCR.insert_cassette 'cenabast/spree/erp/sale_orders/send_to_erp_valid', erb: true
+    end
+
+    after(:each) do
+      VCR.eject_cassette
+    end
+
+    it 'saves status into the sale order' do
+      described_class.new(sale_order).call
+
+      expect(sale_order.status).to eq 'sent'
+    end
+
+    it 'saves erp info into the sale order' do
+      described_class.new(sale_order).call
+
+      expect(sale_order.erp_pedido_id).not_to be_nil
+      expect(sale_order.erp_pv_id).not_to be_nil
+      expect(sale_order.erp_fecha_creacion).not_to be_nil
+    end
+  end
+
+  describe '#call - invalid server response' do
+    before(:each) do
+      VCR.insert_cassette 'cenabast/spree/erp/sale_orders/send_to_erp_invalid', erb: true
+    end
+
+    after(:each) do
+      VCR.eject_cassette
+    end
+
+    it 'raises an error, and sets the status as failed' do
+      expect do
+        described_class.new(sale_order).call
+      end.to raise_error(StandardError)
+
+      expect(sale_order.status).to eq 'failed'
+    end
+  end
+end

--- a/spec/system/checkout_spec.rb
+++ b/spec/system/checkout_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe 'Checkout process', type: :system do
 
     act_with_current_store(store)
     act_as_logged_in(user)
+
+    # Dont do stock validation using API
+    # Mock this, and return true always
+    allow_any_instance_of(Cenabast::Spree::LineItemDecorator).to receive(:sufficient_stock?) { true }
   end
 
   it 'can go through checkout process', js: true do
@@ -31,7 +35,6 @@ RSpec.describe 'Checkout process', type: :system do
     click_link Spree.t('pdp.view_cart')
 
     # Cart view
-
     find_button(Spree.t(:send_order), disabled: false)
     click_button Spree.t(:send_order)
 

--- a/spec/vcr/cenabast/spree/erp/sale_orders/send_to_erp_invalid.yml
+++ b/spec/vcr/cenabast/spree/erp/sale_orders/send_to_erp_invalid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://testaplicacionesweb.cenabast.cl:7001/interoperabilidad/tienda/api/v1/auth
+    uri: "<%= ENV['CENABAST_API_BASE_URL'] %><%= ENV['CENABAST_API_BASE_PATH'] %>/auth"
     body:
       encoding: UTF-8
       string: '{"user":"tienda","password":"tienda#2024"}'
@@ -18,7 +18,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
-      - testaplicacionesweb.cenabast.cl:7001
+      - "<%= ENV['CENABAST_API_BASE_URL'] %>"
   response:
     status:
       code: 200
@@ -42,7 +42,7 @@ http_interactions:
   recorded_at: Wed, 10 Apr 2024 20:26:50 GMT
 - request:
     method: post
-    uri: https://testaplicacionesweb.cenabast.cl:7001/interoperabilidad/tienda/api/v1/pedido
+    uri: "<%= ENV['CENABAST_API_BASE_URL'] %><%= ENV['CENABAST_API_BASE_PATH'] %>/pedido"
     body:
       encoding: UTF-8
       string: '{"RutSolicitante":"26.896.041-4","DetalleProductos":[{"DocumentoCompra":1110,"CodigoOcChilecompra":"123","CodigoMaterial":44220,"CantidadSolicitada":2,"CodigoDestinatario":23,"PuertoDescarga":"ABC","FechaEntrega":"2024-04-19T16:26:50.456-04:00"},{"DocumentoCompra":1111,"CodigoOcChilecompra":"123","CodigoMaterial":44221,"CantidadSolicitada":2,"CodigoDestinatario":23,"PuertoDescarga":"ABC","FechaEntrega":"2024-04-19T16:26:50.459-04:00"},{"DocumentoCompra":1112,"CodigoOcChilecompra":"123","CodigoMaterial":44222,"CantidadSolicitada":2,"CodigoDestinatario":23,"PuertoDescarga":"ABC","FechaEntrega":"2024-04-19T16:26:50.462-04:00"}]}'
@@ -60,7 +60,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
-      - testaplicacionesweb.cenabast.cl:7001
+      - "<%= ENV['CENABAST_API_BASE_URL'] %>"
   response:
     status:
       code: 404

--- a/spec/vcr/cenabast/spree/erp/sale_orders/send_to_erp_invalid.yml
+++ b/spec/vcr/cenabast/spree/erp/sale_orders/send_to_erp_invalid.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://testaplicacionesweb.cenabast.cl:7001/interoperabilidad/tienda/api/v1/auth
+    body:
+      encoding: UTF-8
+      string: '{"user":"tienda","password":"tienda#2024"}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.2.2p53
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - testaplicacionesweb.cenabast.cl:7001
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/10.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1;mode=block
+      Date:
+      - Wed, 10 Apr 2024 20:26:50 GMT
+    body:
+      encoding: UTF-8
+      string: '{"code":200,"isSuccessStatusCode":true,"content":"eyJhbGciOiJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNobWFjLXNoYTI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9zaWQiOiIxOSIsImh0dHA6Ly9zY2hlbWFzLnhtbHNvYXAub3JnL3dzLzIwMDkvMDkvaWRlbnRpdHkvY2xhaW1zL2FjdG9yIjoiVXNlciIsImV4cCI6MTcxMjc4NDQxMSwiaXNzIjoiVElFTkRBLVRFU1QtVEkiLCJhdWQiOiJodHRwczovL3Rlc3RhcGxpY2FjaW9uZXN3ZWIuY2VuYWJhc3QuY2w6NzAwMSJ9.OTCsCNKMT-lmVhF1x91U-Llro9XyepqksbRJDfDxMis"}'
+  recorded_at: Wed, 10 Apr 2024 20:26:50 GMT
+- request:
+    method: post
+    uri: https://testaplicacionesweb.cenabast.cl:7001/interoperabilidad/tienda/api/v1/pedido
+    body:
+      encoding: UTF-8
+      string: '{"RutSolicitante":"26.896.041-4","DetalleProductos":[{"DocumentoCompra":1110,"CodigoOcChilecompra":"123","CodigoMaterial":44220,"CantidadSolicitada":2,"CodigoDestinatario":23,"PuertoDescarga":"ABC","FechaEntrega":"2024-04-19T16:26:50.456-04:00"},{"DocumentoCompra":1111,"CodigoOcChilecompra":"123","CodigoMaterial":44221,"CantidadSolicitada":2,"CodigoDestinatario":23,"PuertoDescarga":"ABC","FechaEntrega":"2024-04-19T16:26:50.459-04:00"},{"DocumentoCompra":1112,"CodigoOcChilecompra":"123","CodigoMaterial":44222,"CantidadSolicitada":2,"CodigoDestinatario":23,"PuertoDescarga":"ABC","FechaEntrega":"2024-04-19T16:26:50.462-04:00"}]}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.2.2p53
+      Authorization:
+      - Bearer eyJhbGciOiJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNobWFjLXNoYTI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9zaWQiOiIxOSIsImh0dHA6Ly9zY2hlbWFzLnhtbHNvYXAub3JnL3dzLzIwMDkvMDkvaWRlbnRpdHkvY2xhaW1zL2FjdG9yIjoiVXNlciIsImV4cCI6MTcxMjc4NDQxMSwiaXNzIjoiVElFTkRBLVRFU1QtVEkiLCJhdWQiOiJodHRwczovL3Rlc3RhcGxpY2FjaW9uZXN3ZWIuY2VuYWJhc3QuY2w6NzAwMSJ9.OTCsCNKMT-lmVhF1x91U-Llro9XyepqksbRJDfDxMis
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '633'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - testaplicacionesweb.cenabast.cl:7001
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/10.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1;mode=block
+      Date:
+      - Wed, 10 Apr 2024 20:26:50 GMT
+    body:
+      encoding: UTF-8
+      string: '{"code":404,"isSuccessStatusCode":false,"content":""}'
+  recorded_at: Wed, 10 Apr 2024 20:26:50 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr/cenabast/spree/erp/sale_orders/send_to_erp_valid.yml
+++ b/spec/vcr/cenabast/spree/erp/sale_orders/send_to_erp_valid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://testaplicacionesweb.cenabast.cl:7001/interoperabilidad/tienda/api/v1/auth
+    uri: "<%= ENV['CENABAST_API_BASE_URL'] %><%= ENV['CENABAST_API_BASE_PATH'] %>/auth"
     body:
       encoding: UTF-8
       string: '{"user":"tienda","password":"tienda#2024"}'
@@ -18,7 +18,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
-      - testaplicacionesweb.cenabast.cl:7001
+      - "<%= ENV['CENABAST_API_BASE_URL'] %>"
   response:
     status:
       code: 200
@@ -42,7 +42,7 @@ http_interactions:
   recorded_at: Wed, 10 Apr 2024 20:26:51 GMT
 - request:
     method: post
-    uri: https://testaplicacionesweb.cenabast.cl:7001/interoperabilidad/tienda/api/v1/pedido
+    uri: "<%= ENV['CENABAST_API_BASE_URL'] %><%= ENV['CENABAST_API_BASE_PATH'] %>/pedido"
     body:
       encoding: UTF-8
       string: '{"RutSolicitante":"26.896.041-4","DetalleProductos":[{"DocumentoCompra":1110,"CodigoOcChilecompra":"123","CodigoMaterial":44220,"CantidadSolicitada":2,"CodigoDestinatario":23,"PuertoDescarga":"ABC","FechaEntrega":"2024-04-19T16:26:51.246-04:00"},{"DocumentoCompra":1111,"CodigoOcChilecompra":"123","CodigoMaterial":44221,"CantidadSolicitada":2,"CodigoDestinatario":23,"PuertoDescarga":"ABC","FechaEntrega":"2024-04-19T16:26:51.251-04:00"},{"DocumentoCompra":1112,"CodigoOcChilecompra":"123","CodigoMaterial":44222,"CantidadSolicitada":2,"CodigoDestinatario":23,"PuertoDescarga":"ABC","FechaEntrega":"2024-04-19T16:26:51.253-04:00"}]}'
@@ -60,7 +60,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
-      - testaplicacionesweb.cenabast.cl:7001
+      - "<%= ENV['CENABAST_API_BASE_URL'] %>"
   response:
     status:
       code: 200

--- a/spec/vcr/cenabast/spree/erp/sale_orders/send_to_erp_valid.yml
+++ b/spec/vcr/cenabast/spree/erp/sale_orders/send_to_erp_valid.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://testaplicacionesweb.cenabast.cl:7001/interoperabilidad/tienda/api/v1/auth
+    body:
+      encoding: UTF-8
+      string: '{"user":"tienda","password":"tienda#2024"}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.2.2p53
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - testaplicacionesweb.cenabast.cl:7001
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/10.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1;mode=block
+      Date:
+      - Wed, 10 Apr 2024 20:26:51 GMT
+    body:
+      encoding: UTF-8
+      string: '{"code":200,"isSuccessStatusCode":true,"content":"eyJhbGciOiJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNobWFjLXNoYTI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9zaWQiOiIxOSIsImh0dHA6Ly9zY2hlbWFzLnhtbHNvYXAub3JnL3dzLzIwMDkvMDkvaWRlbnRpdHkvY2xhaW1zL2FjdG9yIjoiVXNlciIsImV4cCI6MTcxMjc4NDQxMSwiaXNzIjoiVElFTkRBLVRFU1QtVEkiLCJhdWQiOiJodHRwczovL3Rlc3RhcGxpY2FjaW9uZXN3ZWIuY2VuYWJhc3QuY2w6NzAwMSJ9.OTCsCNKMT-lmVhF1x91U-Llro9XyepqksbRJDfDxMis"}'
+  recorded_at: Wed, 10 Apr 2024 20:26:51 GMT
+- request:
+    method: post
+    uri: https://testaplicacionesweb.cenabast.cl:7001/interoperabilidad/tienda/api/v1/pedido
+    body:
+      encoding: UTF-8
+      string: '{"RutSolicitante":"26.896.041-4","DetalleProductos":[{"DocumentoCompra":1110,"CodigoOcChilecompra":"123","CodigoMaterial":44220,"CantidadSolicitada":2,"CodigoDestinatario":23,"PuertoDescarga":"ABC","FechaEntrega":"2024-04-19T16:26:51.246-04:00"},{"DocumentoCompra":1111,"CodigoOcChilecompra":"123","CodigoMaterial":44221,"CantidadSolicitada":2,"CodigoDestinatario":23,"PuertoDescarga":"ABC","FechaEntrega":"2024-04-19T16:26:51.251-04:00"},{"DocumentoCompra":1112,"CodigoOcChilecompra":"123","CodigoMaterial":44222,"CantidadSolicitada":2,"CodigoDestinatario":23,"PuertoDescarga":"ABC","FechaEntrega":"2024-04-19T16:26:51.253-04:00"}]}'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - rest-client/2.1.0 (linux x86_64) ruby/3.2.2p53
+      Authorization:
+      - Bearer eyJhbGciOiJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNobWFjLXNoYTI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9zaWQiOiIxOSIsImh0dHA6Ly9zY2hlbWFzLnhtbHNvYXAub3JnL3dzLzIwMDkvMDkvaWRlbnRpdHkvY2xhaW1zL2FjdG9yIjoiVXNlciIsImV4cCI6MTcxMjc4NDQxMSwiaXNzIjoiVElFTkRBLVRFU1QtVEkiLCJhdWQiOiJodHRwczovL3Rlc3RhcGxpY2FjaW9uZXN3ZWIuY2VuYWJhc3QuY2w6NzAwMSJ9.OTCsCNKMT-lmVhF1x91U-Llro9XyepqksbRJDfDxMis
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '633'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - testaplicacionesweb.cenabast.cl:7001
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/10.0
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1;mode=block
+      Date:
+      - Wed, 10 Apr 2024 20:26:51 GMT
+    body:
+      encoding: UTF-8
+      string: '{"code":200,"isSuccessStatusCode":true,"content":[{"pedidoId":30,"fechaCreacion":"2024-04-10T16:26:51.9028924-04:00","zcen":"44220","pedidoVentaId":55005002},{"pedidoId":30,"fechaCreacion":"2024-04-10T16:26:51.9049211-04:00","zcen":"44221","pedidoVentaId":55005002},{"pedidoId":30,"fechaCreacion":"2024-04-10T16:26:51.9067761-04:00","zcen":"44222","pedidoVentaId":55005002}]}'
+  recorded_at: Wed, 10 Apr 2024 20:26:51 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- https://linets.atlassian.net/browse/PE188-118

## Description

- ERP injection of orders is now managed with a sidekiq/ActiveJob background job
  - Job gets retried 10 times following the backoff function: (60s, 300s, 600s, 1800s, 3600s, 3600s, 3600s)
- Created Cenabast::Spree::Erp::SaleOrder to save ERP sale orders information
  - A Spree::Order can have multiple SaleOrders, depending on how the data is sent.
  - Currently, is sent splitted by providers (using ByProductInjector)
- Created SendToErp service which manages the API call and saving the results into Cenabast::Spree::Erp::SaleOrder 
- SaleOrder status and other information is visible in the backoffice when looking at the detail of an Spree::Order (ie: /admin/orders/R068363448/sale_orders), and also in the Spree::Orders table (/admin/orders) a general method for Spree::Order `#erp_send_status` has been created to see the "overview" of all its sale orders
- Created related factories/specs

## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Rubocop style is passing, and Rspec tests are passing.
- [ ] Documentation has been written (Docs or code)
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
