### PR TITLE
[PE188-126] Various fixes (Milestone 03)

### DIFF
--- a/app/models/cenabast/spree/erp/injector_factory.rb
+++ b/app/models/cenabast/spree/erp/injector_factory.rb
@@ -5,7 +5,10 @@ module Cenabast
       class InjectorFactory
         # Method to create an instance of Injector based on business logic
         def self.create_injector
-          ByVendorInjector.new
+          # Ensure to split each sale order injection into products
+          # The response of the ERP might bring different pedidoVentaSapId per product
+          # we need to make sure to be saving everything.
+          ByProductInjector.new
         end
       end
     end

--- a/app/models/cenabast/spree/generic_product.rb
+++ b/app/models/cenabast/spree/generic_product.rb
@@ -6,7 +6,7 @@ class Cenabast::Spree::GenericProduct < Spree::Base
   validates :code, presence: true, uniqueness: true
 
   self.whitelisted_ransackable_attributes = %w[
-    code code_atc code_onu code_ean denomination standard_denomination
+    name code code_atc code_onu code_ean denomination standard_denomination
     product_type hierarchy ump manufacturer base_table
   ]
 end

--- a/app/models/cenabast/spree/order/stock_validator.rb
+++ b/app/models/cenabast/spree/order/stock_validator.rb
@@ -24,8 +24,12 @@ module Cenabast
 
         private
 
+        def sale_order
+          @sale_order ||= line_item&.product&.contract&.sale_order
+        end
+
         def fetch_information_for_line_item
-          return unless (sale_order = line_item&.product&.contract&.sale_order)
+          return unless sale_order
 
           Cenabast::Api::ValidateStockInformationFetcher.new(sale_order).call
         end

--- a/app/models/cenabast/spree/order/stock_validator.rb
+++ b/app/models/cenabast/spree/order/stock_validator.rb
@@ -39,10 +39,9 @@ module Cenabast
 
           if info&.dig(:success)
             stock_content = info[:response_content].deep_symbolize_keys
-            is_available = stock_content[:estaDisponible]
-            available_quantity = stock_content[:stockDisponible]
+            available_quantity = stock_content[:cantidadDisponible]
 
-            if is_available && available_quantity >= line_item.quantity
+            if available_quantity && available_quantity >= line_item.quantity
               true
             else
               error_messages << ::Spree.t('stock_validator.not_enough_stock', sale_order:)

--- a/app/models/cenabast/spree/order/stock_validator.rb
+++ b/app/models/cenabast/spree/order/stock_validator.rb
@@ -24,13 +24,14 @@ module Cenabast
 
         private
 
-        def fetch_information_for_sku(sku)
-          Cenabast::Api::ValidateStockInformationFetcher.new(sku).call
+        def fetch_information_for_line_item
+          return unless (sale_order = line_item&.product&.contract&.sale_order)
+
+          Cenabast::Api::ValidateStockInformationFetcher.new(sale_order).call
         end
 
         def validate_line_item
-          sku = line_item.sku
-          info = fetch_information_for_sku(sku)
+          info = fetch_information_for_line_item
 
           if info&.dig(:success)
             stock_content = info[:response_content].deep_symbolize_keys
@@ -40,10 +41,10 @@ module Cenabast
             if is_available && available_quantity >= line_item.quantity
               true
             else
-              error_messages << ::Spree.t('stock_validator.not_enough_stock', sku:)
+              error_messages << ::Spree.t('stock_validator.not_enough_stock', sale_order:)
             end
           else
-            error_messages << ::Spree.t('stock_validator.information_retrieve_error', sku:)
+            error_messages << ::Spree.t('stock_validator.information_retrieve_error', sale_order:)
           end
         end
       end

--- a/app/services/cenabast/api/validate_stock_information_fetcher.rb
+++ b/app/services/cenabast/api/validate_stock_information_fetcher.rb
@@ -6,17 +6,17 @@
 module Cenabast
   module Api
     class ValidateStockInformationFetcher < Cenabast::Api::Base
-      attr_accessor :sku
+      attr_accessor :sale_order
 
       def call
         # Avoid usage of cache system, always call the endpoint
         processed_response
       end
 
-      # @param sku [String] SKU of ZCEN to query
-      def initialize(sku)
+      # @param sale_order [String] Sale Order (PedidoId) of ZCEN to query
+      def initialize(sale_order)
         super()
-        @sku = sku
+        @sale_order = sale_order
       end
 
       private
@@ -30,7 +30,7 @@ module Cenabast
       end
 
       def user_path
-        "/pedido/ValidarStock/#{sku}"
+        "/pedido/ValidarStock/#{sale_order}"
       end
     end
   end

--- a/app/services/cenabast/spree/erp/sale_orders/send_to_erp.rb
+++ b/app/services/cenabast/spree/erp/sale_orders/send_to_erp.rb
@@ -43,8 +43,7 @@ module Cenabast
             sale_order.update!(
               status: :sent,
               sent_at: Time.now.in_time_zone,
-              erp_pedido_id: content[:pedidoId],
-              erp_pv_id: content[:pedidoVentaId],
+              erp_pedido_id: content[:pedidoVentaSapId],
               erp_fecha_creacion: content[:fechaCreacion]
             )
           end

--- a/app/views/spree/admin/sale_orders/_sale_order.html.erb
+++ b/app/views/spree/admin/sale_orders/_sale_order.html.erb
@@ -38,11 +38,6 @@
       </div>
 
       <div class="flex flex-row">
-        <strong><%= Spree.t(:erp_pv_id) %>:</strong>
-        <span><%= sale_order.erp_pv_id || '--' %></span>
-      </div>
-
-      <div class="flex flex-row">
         <strong><%= Spree.t(:sent_at) %>:</strong>
         <span><%= sale_order.sent_at || '--' %></span>
       </div>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -61,8 +61,8 @@ es:
       one: "%{count} artículo en total"
       other: "%{count} artículos en total"
     stock_validator:
-      not_enough_stock: 'No hay suficiente stock para el producto "%{sku}".'
-      information_retrieve_error: 'Error al validar stock del producto "%{sku}".'
+      not_enough_stock: 'No hay suficiente stock para el producto "%{sale_order}".'
+      information_retrieve_error: 'Error al validar stock del producto "%{sale_order}".'
     sale_order_statuses:
       initial: 'Inicial'
       sent: 'Enviado'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -70,7 +70,6 @@ es:
       nullified: 'Anulado'
       cancellation_pending: 'Pendiente de cancelación'
     erp_pedido_id: 'ERP Id de Pedido'
-    erp_pv_id: 'ERP ID de PV'
     erp_fecha_creacion: 'ERP Fecha de creación'
     erp_send_status: 'Estado de envio a ERP'
     state_changes: 'Cambios de estado'

--- a/db/migrate/20240417161000_remove_erp_pv_id_from_cenabast_spree_erp_sale_orders.rb
+++ b/db/migrate/20240417161000_remove_erp_pv_id_from_cenabast_spree_erp_sale_orders.rb
@@ -1,0 +1,5 @@
+class RemoveErpPvIdFromCenabastSpreeErpSaleOrders < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :cenabast_spree_erp_sale_orders, :erp_pv_id
+  end
+end

--- a/db/migrate/20240417182421_add_name_to_cenabast_spree_generic_products.rb
+++ b/db/migrate/20240417182421_add_name_to_cenabast_spree_generic_products.rb
@@ -1,0 +1,5 @@
+class AddNameToCenabastSpreeGenericProducts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :cenabast_spree_generic_products, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_17_161000) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_17_182421) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -120,6 +120,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_17_161000) do
     t.string "base_table"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
     t.index ["code"], name: "index_cenabast_spree_generic_products_on_code", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_15_225445) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_17_161000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -97,7 +97,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_15_225445) do
     t.string "number"
     t.integer "status", default: 0, null: false
     t.string "erp_pedido_id"
-    t.string "erp_pv_id"
     t.string "erp_fecha_creacion"
     t.datetime "sent_at"
     t.datetime "nullified_at"

--- a/mage_ai/cenabast/transformers/filter_product_data.py
+++ b/mage_ai/cenabast/transformers/filter_product_data.py
@@ -34,6 +34,10 @@ def transform(data, *args, **kwargs):
         if len(product['contracts']) > 0
     ]
 
+    for product in valid_products:
+        # Set ZGEN of a product
+        product['zgen'] = product['contracts'][0]['zgen']
+
     logger.info(f'Amount of total products (before filter): {len(data)}')
     logger.info(f'Amount of valid products (after filter): {len(valid_products)}')
 

--- a/mage_ai/cenabast/transformers/filter_product_data.py
+++ b/mage_ai/cenabast/transformers/filter_product_data.py
@@ -37,6 +37,8 @@ def transform(data, *args, **kwargs):
     for product in valid_products:
         # Set ZGEN of a product
         product['zgen'] = product['contracts'][0]['zgen']
+        # Set nombreZGEN of a product
+        product['nombreZGEN'] = product['contracts'][0]['nombreZGEN']
 
     logger.info(f'Amount of total products (before filter): {len(data)}')
     logger.info(f'Amount of valid products (after filter): {len(valid_products)}')

--- a/mage_ai/cenabast/utils/data_exporter/generic_product_functions.py
+++ b/mage_ai/cenabast/utils/data_exporter/generic_product_functions.py
@@ -41,6 +41,7 @@ def create_or_update_generic_product(product, api_clients, general_data):
 def build_generic_product_payload(product):
   return {
     "product_type": 'generic',
+    "name": product['nombreZGEN'],
     "code": product['zgen'],
     "code_atc": product['codigoATC'],
     "code_onu": product['codigoONU'],

--- a/mage_ai/cenabast/utils/data_exporter/generic_product_functions.py
+++ b/mage_ai/cenabast/utils/data_exporter/generic_product_functions.py
@@ -1,8 +1,8 @@
 from .date_functions import convert_date
 
 def create_or_update_generic_product(product, api_clients, general_data):
-  # Get code (SKU)
-  codigoProducto = product['codigoProducto']
+  # Get code (SKU, zgen)
+  codigoProducto = product['zgen']
 
   # Get generic product data from Spree API
   existing_generic_product = None
@@ -41,7 +41,7 @@ def create_or_update_generic_product(product, api_clients, general_data):
 def build_generic_product_payload(product):
   return {
     "product_type": 'generic',
-    "code": product['codigoProducto'],
+    "code": product['zgen'],
     "code_atc": product['codigoATC'],
     "code_onu": product['codigoONU'],
     "code_ean": product['codigoEAN'],

--- a/spec/factories/cenabast/spree/generic_product.rb
+++ b/spec/factories/cenabast/spree/generic_product.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :generic_product, class: 'Cenabast::Spree::GenericProduct' do
+    name { Faker::Alphanumeric.alpha(number: 8) }
     code { Faker::Alphanumeric.alpha(number: 8) }
     code_atc { Faker::Alphanumeric.alpha(number: 6) }
     code_onu { Faker::Alphanumeric.alpha(number: 6) }

--- a/spec/models/cenabast/spree/order/stock_validator_spec.rb
+++ b/spec/models/cenabast/spree/order/stock_validator_spec.rb
@@ -16,7 +16,7 @@ module Cenabast
           context 'when line item has enough stock' do
             let(:line_item) do
               create(:line_item, quantity: 4) do |line_item|
-                line_item.variant.update(sku: 'At')
+                create(:contract, product: line_item.product, sale_order: 'At')
               end
             end
 
@@ -36,7 +36,7 @@ module Cenabast
           context 'when line item surpass available quantity' do
             let(:line_item) do
               create(:line_item, quantity: 14) do |line_item|
-                line_item.variant.update(sku: 'At')
+                create(:contract, product: line_item.product, sale_order: 'At')
               end
             end
 
@@ -53,10 +53,10 @@ module Cenabast
             end
           end
 
-          context 'when line item contains invalid sku' do
+          context 'when line item contains invalid sale_order' do
             let(:line_item) do
               create(:line_item, quantity: 4) do |line_item|
-                line_item.variant.update(sku: 'Invalidsku')
+                create(:contract, product: line_item.product, sale_order: 'InvalidSaleOrder')
               end
             end
 

--- a/spec/requests/cenabast/spree/api/v2/platform/generic_products_controller_spec.rb
+++ b/spec/requests/cenabast/spree/api/v2/platform/generic_products_controller_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Cenabast::Spree::Api::V2::Platform::GenericProductsController, ty
 
       attributes = response.parsed_body['data'][0]['attributes']
 
+      expect(attributes['name']).to eq(generic_product.name)
       expect(attributes['code']).to eq(generic_product.code)
       expect(attributes['code_atc']).to eq(generic_product.code_atc)
       expect(attributes['code_onu']).to eq(generic_product.code_onu)
@@ -57,6 +58,7 @@ RSpec.describe Cenabast::Spree::Api::V2::Platform::GenericProductsController, ty
     let(:generic_product_payload) do
       {
         generic_product: {
+          name: 'NEW generic product',
           code: 'NewCode1asdasd2342',
           code_atc: 'ewcwiy',
           code_onu: 'jxabos',

--- a/spec/services/cenabast/api/validate_stock_information_fetcher_spec.rb
+++ b/spec/services/cenabast/api/validate_stock_information_fetcher_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Cenabast::Api::ValidateStockInformationFetcher do
       VCR.eject_cassette
     end
 
-    let(:sku) { '500006843' }
-    let(:response) { described_class.new(sku).call }
+    let(:sale_order) { '4500028294' }
+    let(:response) { described_class.new(sale_order).call }
 
     it 'returns a response with a http_code' do
       expect(response&.dig(:http_code)).to eq 200
@@ -35,8 +35,8 @@ RSpec.describe Cenabast::Api::ValidateStockInformationFetcher do
       VCR.eject_cassette
     end
 
-    let(:sku) { '500006843' }
-    let(:response) { described_class.new(sku).call }
+    let(:sale_order) { '4500028294' }
+    let(:response) { described_class.new(sale_order).call }
 
     it 'returns a response with a http_code' do
       expect(response&.dig(:http_code)).not_to eq 200

--- a/spec/services/cenabast/spree/erp/sale_orders/send_to_erp_spec.rb
+++ b/spec/services/cenabast/spree/erp/sale_orders/send_to_erp_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe Cenabast::Spree::Erp::SaleOrders::SendToErp do
 
       expect(sale_order.sent_at).not_to be_nil
       expect(sale_order.erp_pedido_id).not_to be_nil
-      expect(sale_order.erp_pv_id).not_to be_nil
       expect(sale_order.erp_fecha_creacion).not_to be_nil
     end
   end

--- a/spec/vcr/cenabast/api/stock_validator_valid.yml
+++ b/spec/vcr/cenabast/api/stock_validator_valid.yml
@@ -82,7 +82,7 @@ http_interactions:
   recorded_at: Tue, 26 Mar 2024 15:35:22 GMT
 - request:
     method: get
-    uri: "<%= ENV['CENABAST_API_BASE_URL'] %><%= ENV['CENABAST_API_BASE_PATH'] %>/pedido/ValidarStock/Invalidsku"
+    uri: "<%= ENV['CENABAST_API_BASE_URL'] %><%= ENV['CENABAST_API_BASE_PATH'] %>/pedido/ValidarStock/InvalidSaleOrder"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/cenabast/api/stock_validator_valid.yml
+++ b/spec/vcr/cenabast/api/stock_validator_valid.yml
@@ -78,7 +78,8 @@ http_interactions:
       - Tue, 26 Mar 2024 15:35:23 GMT
     body:
       encoding: UTF-8
-      string: '{"code":200,"isSuccessStatusCode":true,"content":{"stockDisponible":5,"estaDisponible":true}}'
+      
+      string: '{"code":200,"isSuccessStatusCode":true,"content": {"documentoCompra": 4500033315,"codigoMaterial": 500016140,"cantidadDisponible": 5}}'
   recorded_at: Tue, 26 Mar 2024 15:35:22 GMT
 - request:
     method: get

--- a/spec/vcr/cenabast/api/validate_stock_information_invalid.yml
+++ b/spec/vcr/cenabast/api/validate_stock_information_invalid.yml
@@ -42,7 +42,7 @@ http_interactions:
   recorded_at: Tue, 26 Mar 2024 15:25:08 GMT
 - request:
     method: get
-    uri: "<%= ENV['CENABAST_API_BASE_URL'] %><%= ENV['CENABAST_API_BASE_PATH'] %>/pedido/ValidarStock/500006843"
+    uri: "<%= ENV['CENABAST_API_BASE_URL'] %><%= ENV['CENABAST_API_BASE_PATH'] %>/pedido/ValidarStock/4500028294"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/cenabast/api/validate_stock_information_valid.yml
+++ b/spec/vcr/cenabast/api/validate_stock_information_valid.yml
@@ -42,7 +42,7 @@ http_interactions:
   recorded_at: Tue, 26 Mar 2024 15:25:08 GMT
 - request:
     method: get
-    uri: "<%= ENV['CENABAST_API_BASE_URL'] %><%= ENV['CENABAST_API_BASE_PATH'] %>/pedido/ValidarStock/500006843"
+    uri: "<%= ENV['CENABAST_API_BASE_URL'] %><%= ENV['CENABAST_API_BASE_PATH'] %>/pedido/ValidarStock/4500028294"
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/cenabast/api/validate_stock_information_valid.yml
+++ b/spec/vcr/cenabast/api/validate_stock_information_valid.yml
@@ -78,6 +78,6 @@ http_interactions:
       - Tue, 26 Mar 2024 15:25:08 GMT
     body:
       encoding: UTF-8
-      string: '{"code":200,"isSuccessStatusCode":true,"content":{"stockDisponible":5,"estaDisponible":true}}'
+      string: '{"code":200,"isSuccessStatusCode":true,"content": {"documentoCompra": 4500028294,"codigoMaterial": 500016140,"cantidadDisponible": 5}}'
   recorded_at: Tue, 26 Mar 2024 15:25:08 GMT
 recorded_with: VCR 6.2.0

--- a/spec/vcr/cenabast/spree/erp/sale_orders/send_to_erp_valid.yml
+++ b/spec/vcr/cenabast/spree/erp/sale_orders/send_to_erp_valid.yml
@@ -80,6 +80,6 @@ http_interactions:
       - Wed, 10 Apr 2024 20:26:51 GMT
     body:
       encoding: UTF-8
-      string: '{"code":200,"isSuccessStatusCode":true,"content":[{"pedidoId":30,"fechaCreacion":"2024-04-10T16:26:51.9028924-04:00","zcen":"44220","pedidoVentaId":55005002},{"pedidoId":30,"fechaCreacion":"2024-04-10T16:26:51.9049211-04:00","zcen":"44221","pedidoVentaId":55005002},{"pedidoId":30,"fechaCreacion":"2024-04-10T16:26:51.9067761-04:00","zcen":"44222","pedidoVentaId":55005002}]}'
+      string: '{"code":200,"isSuccessStatusCode":true,"content":[{"pedidoVentaSapId":30,"fechaCreacion":"2024-04-10T16:26:51.9028924-04:00","zcen":"44220"},{"pedidoVentaSapId":30,"fechaCreacion":"2024-04-10T16:26:51.9049211-04:00","zcen":"44221"},{"pedidoVentaSapId":30,"fechaCreacion":"2024-04-10T16:26:51.9067761-04:00","zcen":"44222"}]}'
   recorded_at: Wed, 10 Apr 2024 20:26:51 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- https://linets.atlassian.net/browse/PE188-126

## Description

- Correct how ZGEN is saved in product sync pipeline.
- Product sync process now saves nombreZGEN into the field `name` of Cenabast::Spree::GenericProduct
- Change how validateStock endpoint is called, use pedidoId instead of SKU/ZCEN code
- validateStock service now uses cantidadDisponible instead of estaDisponible/stockDisponible to determine availablity
- Remove unused field erp_pv_id from SaleOrders
- Update how erp_pedido_id is saved, now using pedidoVentaSapId
- SaleOrders are now divided by each line item in an order to ensure all erp_pedido_id are saved

## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- [x] There are tests covering new/changed functionality
- [x] Rubocop style is passing, and Rspec tests are passing.
- [x] Documentation has been written (Docs or code)
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x] Proper labels assigned. Use `WIP` label to indicate that state
