### PR TITLE
[PE188-130] Various cosmetic adjustments #1

### DIFF
--- a/app/controllers/cenabast/spree/store_controller_decorator.rb
+++ b/app/controllers/cenabast/spree/store_controller_decorator.rb
@@ -3,6 +3,7 @@ module Cenabast
     module StoreControllerDecorator
       def self.prepended(base)
         base.helper 'cenabast/spree/cenabast'
+        base.helper 'cenabast/spree/cenabast_products'
       end
     end
   end

--- a/app/helpers/cenabast/spree/cenabast_products_helper.rb
+++ b/app/helpers/cenabast/spree/cenabast_products_helper.rb
@@ -1,0 +1,12 @@
+module Cenabast
+  module Spree
+    module CenabastProductsHelper
+      def mercado_publico_link_for_product(product)
+        mercado_publico_id = product&.contract&.mercado_publico_id || '--'
+
+        result_url = "https://www.mercadopublico.cl/Procurement/Modules/RFB/DetailsAcquisition.aspx?idlicitacion=#{mercado_publico_id}"
+        link_to(mercado_publico_id, result_url, { class: 'underline underline-offset-1' })
+      end
+    end
+  end
+end

--- a/app/views/spree/products/show.html.erb
+++ b/app/views/spree/products/show.html.erb
@@ -20,7 +20,10 @@
             <%= @product.generic_product&.denomination %>
           </div>
           <div class="text-sm text-gray-400">
-            SKU: <%= @product.sku %>
+            <%= Spree.t(:zcen) %>: <%= @product&.contract&.code || '--' %>
+          </div>
+          <div class="text-sm text-gray-400">
+            <%= Spree.t(:zgen) %>: <%= @product&.generic_product&.code || '--' %>
           </div>
 
           <div class="mt-7 mb-4">

--- a/app/views/spree/products/show.html.erb
+++ b/app/views/spree/products/show.html.erb
@@ -31,15 +31,15 @@
             <div class="grid grid-cols-3 gap-2 text-sm text-gray-400 mt-2">
               <div class="flex flex-col gap-1">
                 <span class="text-gray-500 font-black"><%= Spree.t('pdp.mercado_publico_id') %></span>
-                <span><%= @product.contract&.mercado_publico_id %></span>
+                <span><%= mercado_publico_link_for_product(@product) %></span>
               </div>
               <div class="flex flex-col gap-1 pl-3 border-l border-gray-300">
                 <span class="text-gray-500 font-black"><%= Spree.t('pdp.atc_code') %></span>
-                <span><%= @product.generic_product&.code_atc %></span>
+                <span><%= @product.generic_product&.code_atc || '--' %></span>
               </div>
               <div class="flex flex-col gap-1 pl-3 border-l border-gray-300">
                 <span class="text-gray-500 font-black"><%= Spree.t('pdp.standard_denomination') %></span>
-                <span><%= @product.generic_product&.standard_denomination %></span>
+                <span><%= @product.generic_product&.standard_denomination || '--' %></span>
               </div>
             </div>
           </div>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -79,6 +79,8 @@ es:
     nullified_at: 'Fecha Anulación'
     search_by: 'Buscar por'
     search_order_number: 'Numero de Orden'
+    zcen: 'ZCEN'
+    zgen: 'ZGEN'
     admin:
       orders:
         nullify_pending: 'Pendiente de cancelación'

--- a/spec/system/product_page_spec.rb
+++ b/spec/system/product_page_spec.rb
@@ -18,7 +18,15 @@ RSpec.describe 'Visiting Product Page', type: :system do
     visit "/products/#{product.slug}"
   end
 
-  it 'should display product`s ATC code' do
+  it 'should display product`s generic product ATC code' do
     expect(page).to have_text(product.generic_product.code_atc)
+  end
+
+  it 'should display product`s generic product ZGEN code' do
+    expect(page).to have_text(product.generic_product.code)
+  end
+
+  it 'should display product`s contract ZCEN code' do
+    expect(page).to have_text(product.contract.code)
   end
 end

--- a/spec/system/product_page_spec.rb
+++ b/spec/system/product_page_spec.rb
@@ -29,4 +29,9 @@ RSpec.describe 'Visiting Product Page', type: :system do
   it 'should display product`s contract ZCEN code' do
     expect(page).to have_text(product.contract.code)
   end
+
+  it 'should have link to mercado publico licitation page' do
+    url = "https://www.mercadopublico.cl/Procurement/Modules/RFB/DetailsAcquisition.aspx?idlicitacion=#{product.contract.mercado_publico_id}"
+    expect(page).to have_link(product.contract.mercado_publico_id, href: url)
+  end
 end


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- https://linets.atlassian.net/browse/PE188-130

## Description

- Display ZGEN and ZCEN in product page, change text to say ZCEN instead of SKU
- Display link to mercado publico licitation page in product show page

## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- [x] There are tests covering new/changed functionality
- [x] Rubocop style is passing, and Rspec tests are passing.
- [x] Documentation has been written (Docs or code)
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x] Proper labels assigned. Use `WIP` label to indicate that state
