### PR TITLE
[PE188-134] Add sale unit to product show view

### DIFF
--- a/app/views/spree/products/show.html.erb
+++ b/app/views/spree/products/show.html.erb
@@ -23,7 +23,7 @@
             SKU: <%= @product.sku %>
           </div>
           <div class="text-sm text-gray-400">
-            <%= Spree.t('pdp.sale_unit') %>: <%= @product.contract&.unit_sale %>
+            <%= Spree.t('pdp.sale_unit') %>: <%= @product.contract&.unit_sale || '--' %>
           </div>
 
           <div class="mt-7 mb-4">

--- a/app/views/spree/products/show.html.erb
+++ b/app/views/spree/products/show.html.erb
@@ -22,6 +22,9 @@
           <div class="text-sm text-gray-400">
             SKU: <%= @product.sku %>
           </div>
+          <div class="text-sm text-gray-400">
+            <%= Spree.t('pdp.sale_unit') %>: <%= @product.contract&.unit_sale %>
+          </div>
 
           <div class="mt-7 mb-4">
             <span><%= Spree.t('pdp.about_product') %></span>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -50,6 +50,7 @@ es:
       mercado_publico_id: 'ID Mercado público'
       atc_code: 'Código ATC'
       standard_denomination: 'Denominación estándar'
+      sale_unit: 'Unidad de Venta'
     delivery_method_for_products_of_vendor: 'Método de entrega %{name}'
     no_laboratory: 'Sin Laboratorio'
     send_order: 'Enviar orden'


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- [PE188-134](https://linets.atlassian.net/browse/PE188-134)

## Description

- Add sale unit value from `cenabast_spree_contracts` table to product detail page

<img width="1126" alt="Captura de pantalla 2024-04-18 a la(s) 10 39 30 a  m" src="https://github.com/Departamento-TI/cenabast-tienda/assets/156840296/271029a4-6387-4685-a0fb-22cb490cdb6a">


## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Rubocop style is passing, and Rspec tests are passing.
- [ ] Documentation has been written (Docs or code)
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
