### PR TITLE
[PE188-130] Add GenericProduct name in products #show page

### DIFF
--- a/app/views/spree/products/show.html.erb
+++ b/app/views/spree/products/show.html.erb
@@ -17,7 +17,7 @@
             <%= @product.name %>
           </h1>
           <div class="text-sm text-gray-400">
-            <%= @product.generic_product&.denomination %>
+            <%= @product&.generic_product&.name || '--' %>
           </div>
           <div class="text-sm text-gray-400">
             <%= Spree.t(:zcen) %>: <%= @product&.contract&.code || '--' %>

--- a/mage_ai/cenabast/utils/data_exporter/product_functions.py
+++ b/mage_ai/cenabast/utils/data_exporter/product_functions.py
@@ -70,7 +70,6 @@ def build_filter_payload_update(payload):
       'sku',
       'shipping_category_id',
       'status',
-      'generic_product_id',
       'vendor_id'
     ]
     filter_payload = {key: value for key, value in payload.items() if key not in not_allowed_keys }

--- a/spec/system/product_page_spec.rb
+++ b/spec/system/product_page_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe 'Visiting Product Page', type: :system do
     visit "/products/#{product.slug}"
   end
 
+  it 'should display product`s generic product name' do
+    expect(page).to have_text(product.generic_product.name)
+  end
+
   it 'should display product`s generic product ATC code' do
     expect(page).to have_text(product.generic_product.code_atc)
   end


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- https://linets.atlassian.net/browse/PE188-130

## Description
- Add GenericProduct name in products #show page, replace instead of GenericProduct denomination
- Allow update of generic product in product sync process (generic product is now longer "locked" onto the product, it can be updated in posterior updates if needed)

![image](https://github.com/Departamento-TI/cenabast-tienda/assets/156705333/736351f9-0374-41b6-932d-00af8725dc43)


## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Rubocop style is passing, and Rspec tests are passing.
- [ ] Documentation has been written (Docs or code)
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
