### PR TITLE
[PE188-136] Remove description section from PDP, add bottom padding

### DIFF
--- a/app/views/spree/products/show.html.erb
+++ b/app/views/spree/products/show.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <% cache cache_key_for_product do %>
-  <div class="container pt-4 product-details">
+  <div class="container py-4 product-details">
     <div class="row" data-hook="product_show">
       <%= render partial: 'gallery' %>
       <div class="col-12 col-md-5" data-hook="product_right_part">
@@ -51,11 +51,6 @@
             <%= render 'cart_form', variant_change_identifier: 'productCarousel' %>
           </div>
         </div>
-      </div>
-    </div>
-    <div class="pb-4 pt-md-5 row" data-hook="product_description">
-      <div class="col-12 col-md-7 col-lg-6">
-        <%= render partial: 'description' %>
       </div>
     </div>
 


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- [PE188-136](https://linets.atlassian.net/browse/PE188-136)

## Description

- Remove description section from PDP

<img width="1524" alt="Captura de pantalla 2024-04-19 a la(s) 11 03 46 a  m" src="https://github.com/Departamento-TI/cenabast-tienda/assets/156840296/01ccf993-4a3f-4c42-9569-62a539cb4ca2">


## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Rubocop style is passing, and Rspec tests are passing.
- [ ] Documentation has been written (Docs or code)
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
