### PR TITLE
[PE188-126-146] Mark nonrequired fields in checkout

### DIFF
--- a/app/components/order/checkout/step/address_form_component.html.erb
+++ b/app/components/order/checkout/step/address_form_component.html.erb
@@ -51,31 +51,31 @@
           </div>
 
           <div class="flex flex-1 flex-col gap-1.5">
-            <span><%= Spree.t(:office) %> *</span>
-            <%= address_form.text_field :office, class: 'text-base bg-gray-50 border border-gray-300 rounded-lg py-3 px-4 min-h-[48px]', required: true %>
+            <span><%= Spree.t(:office) %></span>
+            <%= address_form.text_field :office, class: 'text-base bg-gray-50 border border-gray-300 rounded-lg py-3 px-4 min-h-[48px]', required: false %>
           </div>
         </div>
 
         <div class="m-3 px-2 gap-6 flex flex-row text-gray-400 text-sm">
           <div class="flex flex-1 flex-col gap-1.5">
-            <span><%= Spree.t(:region) %> *</span>
+            <span><%= Spree.t(:region) %></span>
 
             <%== address_form.collection_select(:state_id, states,
                                   :id, :name,
                                   { include_blank: Spree.t(:select_a_state) },
                                   { class: 'state-select text-base bg-white border border-gray-300 rounded-lg py-3 px-4 pr-8 min-h-[48px]',
-                                  required: true,
+                                  required: false,
                                   disabled: false}) %>
           </div>
 
           <div class="flex flex-1 flex-col gap-1.5">
-            <span><%= Spree.t(:county) %> *</span>
+            <span><%= Spree.t(:county) %></span>
 
             <%== address_form.collection_select(:county_id, counties_for_address(@order&.bill_address),
                                   :id, :name,
                                   { include_blank: Spree.t(:select_a_county) },
                                   { class: 'county-select text-base bg-white border border-gray-300 rounded-lg py-3 px-4 pr-8 min-h-[48px]',
-                                  required: true,
+                                  required: false,
                                   disabled: (!@order&.bill_address&.county) }) %>
           </div>
         </div>
@@ -150,31 +150,31 @@
           </div>
 
           <div class="flex flex-1 flex-col gap-1.5">
-            <span><%= Spree.t(:office) %> *</span>
-            <%= address_form.text_field :office, class: 'text-base bg-gray-50 border border-gray-300 rounded-lg py-3 px-4 min-h-[48px]', required: true %>
+            <span><%= Spree.t(:office) %></span>
+            <%= address_form.text_field :office, class: 'text-base bg-gray-50 border border-gray-300 rounded-lg py-3 px-4 min-h-[48px]', required: false %>
           </div>
         </div>
 
         <div class="m-3 px-2 gap-6 flex flex-row text-gray-400 text-sm">
           <div class="flex flex-1 flex-col gap-1.5">
-            <span><%= Spree.t(:region) %> *</span>
+            <span><%= Spree.t(:region) %></span>
 
             <%== address_form.collection_select(:state_id, states,
                                   :id, :name,
                                   { include_blank: Spree.t(:select_a_state) },
                                   { class: 'state-select text-base bg-white border border-gray-300 rounded-lg py-3 px-4 pr-8 min-h-[48px]',
-                                  required: true,
+                                  required: false,
                                   disabled: false}) %>
           </div>
 
           <div class="flex flex-1 flex-col gap-1.5">
-            <span><%= Spree.t(:county) %> *</span>
+            <span><%= Spree.t(:county) %></span>
 
             <%== address_form.collection_select(:county_id, counties_for_address(@order&.ship_address),
                                   :id, :name,
                                   { include_blank: Spree.t(:select_a_county) },
                                   { class: 'county-select text-base bg-white border border-gray-300 rounded-lg py-3 px-4 pr-8 min-h-[48px]',
-                                  required: true,
+                                  required: false,
                                   disabled: (!@order&.ship_address&.county) }) %>
           </div>
         </div>

--- a/app/models/cenabast/spree/address_decorator.rb
+++ b/app/models/cenabast/spree/address_decorator.rb
@@ -4,20 +4,26 @@ module Cenabast
       def self.prepended(base)
         base.include Cenabast::Spree::HasCounty
         base.include Cenabast::Spree::HasRun
+
         base.before_validation :adjust_missing_fields
       end
 
       private
 
       def adjust_missing_fields
-        # Spree has validators for those two fields
+        # Spree has validators for those fields
         # Place some filler values if needed
         self.lastname ||= '--'
-        self.city ||= county&.name
+        self.city ||= county&.name || '--'
       end
     end
   end
 end
+
+Spree::Address::ADDRESS_FIELDS = %w(
+  firstname lastname company address1 address1_number
+  address2 city state zipcode country phone
+)
 
 not_included = Spree::Address.included_modules.exclude?(Cenabast::Spree::AddressDecorator)
 Spree::Address.prepend Cenabast::Spree::AddressDecorator if not_included

--- a/app/models/concerns/cenabast/spree/has_county.rb
+++ b/app/models/concerns/cenabast/spree/has_county.rb
@@ -5,18 +5,20 @@ module Cenabast
       extend ActiveSupport::Concern
 
       included do
-        belongs_to :county, class_name: 'Spree::County', optional: false
+        belongs_to :county, class_name: 'Spree::County', optional: true
         validate :county_validate
 
         private
 
         def validate_state_belongs_to_country?
+          return true unless state
           return true if state&.country == country
 
           errors.add(:state, :invalid)
         end
 
         def validate_county_belongs_to_state?
+          return true unless county
           return true if county&.state == state
 
           errors.add(:county, :invalid)

--- a/app/services/cenabast/api/validate_stock_information_fetcher.rb
+++ b/app/services/cenabast/api/validate_stock_information_fetcher.rb
@@ -21,6 +21,13 @@ module Cenabast
 
       private
 
+      def response_successful?
+        response_accepted_http_statuses.include?(response&.code) &&
+          response_body&.dig('isSuccessStatusCode')
+      rescue StandardError
+        nil
+      end
+
       def cache_expire_time
         0.to_i.minutes
       end

--- a/app/views/spree/admin/shared/_address_form.html.erb
+++ b/app/views/spree/admin/shared/_address_form.html.erb
@@ -1,0 +1,50 @@
+<% s_or_b = type.chars.first %>
+<div id="<%= type %>" data-hook="address_fields">
+  <% Spree::Address::ADDRESS_FIELDS.each do |field| %>
+    <% if field == "country" %>
+      <%= field_container (s_or_b + '_' + field), nil, class: ["#{type}-row"] do %>
+        <%= f.label :country_id, Spree.t(:country) %>
+        <div id="<%= s_or_b %>country">
+          <%= f.collection_select :country_id, all_countries, :id, :name, {}, { class: 'select2 w-100' } %>
+        </div>
+      <% end %>
+    <% elsif field == "state" %>
+      <%= field_container (s_or_b + '_' + field), :state, class: ["#{type}-row"] do %>
+        <%= f.label :state_id, Spree.t(:state) %>
+        <div id="<%= s_or_b %>state">
+          <% if f.object.country.try(:states) %>
+            <%= f.text_field :state_name,
+                             style: "display: #{f.object.country.try(:states) && f.object.country.states.empty? ? 'block' : 'none' };",
+                             disabled: !(f.object.country.try(:states) && f.object.country.states.empty?), class: 'form-control state_name' %>
+            <%= f.collection_select :state_id, f.object.country.states.sort, :id, :name, { include_blank: true }, { class: 'select2 w-100', disabled: f.object.country.states.empty? } %>
+          <% else %>
+            <div>
+              <em><%= Spree.t(:no_country) %></em>
+            </div>
+          <% end %>
+        </div>
+        <%= error_message_on f.object, :state_id %>
+      <% end %>
+
+      <%= field_container (s_or_b + '_' + 'county'), nil, class: ["#{type}-row"] do %>
+        <%= f.label :county, Spree.t(:county) %>
+        <%= f.text_field :county, value: f.object&.county&.name, class: 'form-control', disabled: true %>
+        <%= error_message_on f.object, :county %>
+      <% end %>
+    <% else %>
+      <%= field_container (s_or_b + '_' + field), nil, class: ["#{type}-row"] do %>
+        <%= f.label field, Spree.t(field) %>
+        <%= f.text_field field, class: 'form-control' %>
+        <%= error_message_on f.object, field %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>
+
+<% content_for :head do %>
+  <script>
+    document.addEventListener("spree:load", function() {
+      $('#<%= s_or_b %>country select').on('change', function() { updateAddressState('<%= s_or_b %>'); });
+    })
+  </script>
+<% end %>

--- a/app/views/spree/shared/_address.html.erb
+++ b/app/views/spree/shared/_address.html.erb
@@ -8,7 +8,7 @@
   <div class="adr text-base text-gray-700">
     <div class="street-address">
       <div class="street-address-line">
-        <%= address.address1 %>
+        <%= address.address1 %> <%= address.address1_number %>
       </div>
       <% unless address.address2.blank? %>
         <div class="street-address-line">

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -82,11 +82,12 @@ es:
     product_name: 'Nombre producto'
     search: 'Buscar producto'
     search_by: 'Buscar por'
-    search_order_number: 'Numero de Orden'
+    search_order_number: 'Número de Orden'
     zcen: 'ZCEN'
     zgen: 'ZGEN'
     min: 'Minimo'
     max: 'Máximo'
+    address1_number: 'Número Dirección'
     admin:
       orders:
         nullify_pending: 'Pendiente de cancelación'

--- a/db/migrate/20240424184738_ensure_chile_states_required_to_false.rb
+++ b/db/migrate/20240424184738_ensure_chile_states_required_to_false.rb
@@ -1,0 +1,25 @@
+class EnsureChileStatesRequiredToFalse < ActiveRecord::Migration[7.1]
+  def up
+    return unless chile
+
+    chile.update(states_required: false)
+  end
+
+  def down
+    return unless chile
+
+    chile.update(states_required: true)
+  end
+
+  private
+
+  def chile
+    @chile ||= Spree::Country.find_by(
+      name: 'Chile',
+      iso_name: 'CHILE',
+      iso: 'CL',
+      iso3: 'CHL',
+      numcode: 152
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_17_182421) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_24_184738) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/seeds/004_states_and_counties.rb
+++ b/db/seeds/004_states_and_counties.rb
@@ -1,5 +1,5 @@
 country = Spree::Country.find_by(name: 'Chile', iso_name: 'CHILE', iso: 'CL', iso3: 'CHL', numcode: 152)
-country.update(states_required: true)
+country.update(states_required: false)
 country.update(zipcode_required: false)
 
 # Chilean states

--- a/spec/models/spree/address_spec.rb
+++ b/spec/models/spree/address_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Address, type: :model do
+  describe 'Canceled validations' do
+    it 'cancels validation for :state' do
+      expect(described_class._validators[:state]).to be_empty
+    end
+  end
+
   describe 'Has Run concern' do
     describe 'Validations' do
       it { should validate_presence_of :run }
@@ -18,7 +24,7 @@ RSpec.describe Spree::Address, type: :model do
 
   describe 'Has County concern' do
     describe 'Associations' do
-      it { should belong_to(:county).class_name('Spree::County').required }
+      it { should belong_to(:county).class_name('Spree::County').optional }
     end
 
     it 'validates state belongs to country' do

--- a/spec/support/helpers/checkout_helper.rb
+++ b/spec/support/helpers/checkout_helper.rb
@@ -2,7 +2,7 @@ module Helpers
   module CheckoutHelper
     def fill_checkout_form_field(label, value)
       # Find the input field based on the adjacent span tag value
-      input_field = find(:xpath, "//span[text()='#{label} *']/following-sibling::input")
+      input_field = find(:xpath, "//span[text()='#{label}']/following-sibling::input")
 
       # Fill the input field with your desired value
       input_field.set(value)
@@ -10,7 +10,7 @@ module Helpers
 
     def select_checkout_form_field(label, value)
       # Find the input field based on the adjacent span tag value
-      input_field = find(:xpath, "//span[text()='#{label} *']/following-sibling::select")
+      input_field = find(:xpath, "//span[text()='#{label}']/following-sibling::select")
 
       # Fill the input field with your desired value
       input_field.select(value)

--- a/spec/support/helpers/store_helper.rb
+++ b/spec/support/helpers/store_helper.rb
@@ -5,7 +5,7 @@ module Helpers
       Spree::Country.find_or_create_by(
         name: 'Chile', iso_name: 'CHILE',
         iso: 'CL', iso3: 'CHL', numcode: 152,
-        states_required: true, zipcode_required: false
+        states_required: false, zipcode_required: false
       )
 
       ecommerce_store = create(:store, code: 'spree-ecommerce', name: 'E-commerce')
@@ -36,6 +36,7 @@ module Helpers
     # Create some sample values to use
     def create_states_and_counties
       country = Spree::Country.find_by(iso: 'CL')
+
       state = create(:state, country:, name: 'Región Metropolitana de Santiago')
       create(:county, state:, name: 'Renca')
       create(:county, state:, name: 'Santiago')


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- https://linets.atlassian.net/browse/PE188-126
- https://linets.atlassian.net/browse/PE188-146

## Description

- Disable state, county and office as required fields for spree addresses in checkout, add related specs
- Add better handling to stock validate response success status
  - Now considering isSuccessStatusCode to be true in response
- Now displays Address number and county to admin, show order after checkout page


## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Rubocop style is passing, and Rspec tests are passing.
- [ ] Documentation has been written (Docs or code)
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
