### PR TITLE
[PE188-126] Fix redirect when changing store: Now #toggle_store will always redirect to spree.root_path

### DIFF
--- a/app/controllers/cenabast/spree/user_preferences_controller.rb
+++ b/app/controllers/cenabast/spree/user_preferences_controller.rb
@@ -25,7 +25,7 @@ module Cenabast
       def toggle_store
         spree_current_user&.toggle_store(@store)
 
-        redirect_back_or_to spree.root_path
+        redirect_to spree.root_path
       end
 
       private

--- a/spec/requests/cenabast/spree/user_preferences_spec.rb
+++ b/spec/requests/cenabast/spree/user_preferences_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe Cenabast::Spree::UserPreferencesController, type: :request do
       expect(user.reload.current_store).not_to eq(store)
     end
 
-    it 'redirects back to the fallback location if provided' do
+    it 'redirects back to the spree root path even if location if provided' do
       post toggle_store_path(option_id: 5), headers: { HTTP_REFERER: '/fallback_location' }
 
-      expect(response).to redirect_to('/fallback_location')
+      expect(response).to redirect_to(spree.root_path)
     end
   end
 


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- https://github.com/Departamento-TI/cenabast-tienda/issues/105
- https://linets.atlassian.net/browse/PE188-126

## Description

- Ensure that #toggle_store action always redirects to spree.root_path, to avoid getting 404 and other ActiveRecord::RecordNotFound exceptions from trying to fetch things that dont exist in the new current store.

## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- [x] There are tests covering new/changed functionality
- [x] Rubocop style is passing, and Rspec tests are passing.
- [x] Documentation has been written (Docs or code)
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x] Proper labels assigned. Use `WIP` label to indicate that state
