### PR TITLE
[PE188-148] Fix change order when requester changes

### DIFF
--- a/app/components/common/layout/header_component.html.erb
+++ b/app/components/common/layout/header_component.html.erb
@@ -50,7 +50,7 @@
         <%= link_to spree.cart_path do %>
           <%= render Common::Button::IconComponent.new(
             button_params: {
-              text: 'Articulos (0)',
+              text: 'Articulos',
               hierarchy: 'primary',
               size: 'lg',
             },

--- a/app/controllers/cenabast/spree/user_preferences_controller.rb
+++ b/app/controllers/cenabast/spree/user_preferences_controller.rb
@@ -14,11 +14,6 @@ module Cenabast
       def toggle_receiver
         spree_current_user&.toggle_receiver(@receiver)
 
-        # token set to nil forcing to find a new current_order
-        cookies.signed[:token] = nil
-        current_order(create_order_if_necessary: true)
-
-        cookies[:toggle_receiver] = true
         redirect_back_or_to spree.root_path
       end
 

--- a/app/controllers/cenabast/spree/user_preferences_controller.rb
+++ b/app/controllers/cenabast/spree/user_preferences_controller.rb
@@ -4,6 +4,7 @@ module Cenabast
       before_action :find_requester, only: [:toggle_requester]
       before_action :find_receiver, only: [:toggle_receiver]
       before_action :find_store, only: [:toggle_store]
+      after_action :reset_current_order, only: [:toggle_receiver, toggle_requester]
 
       def toggle_requester
         spree_current_user&.toggle_requester(@requester)
@@ -35,6 +36,16 @@ module Cenabast
 
       def find_store
         @store = ::Spree::Store.find_by(id: params[:option_id] || params[:store_id])
+      end
+
+      def reset_current_order
+        return unless spree_current_user.current_receiver_previously_changed?
+
+        # token set to nil forcing to find a new current_order
+        cookies.signed[:token] = nil
+        current_order(create_order_if_necessary: true)
+
+        cookies[:reset_order] = true
       end
     end
   end

--- a/app/controllers/cenabast/spree/user_preferences_controller.rb
+++ b/app/controllers/cenabast/spree/user_preferences_controller.rb
@@ -4,7 +4,7 @@ module Cenabast
       before_action :find_requester, only: [:toggle_requester]
       before_action :find_receiver, only: [:toggle_receiver]
       before_action :find_store, only: [:toggle_store]
-      after_action :reset_current_order, only: [:toggle_receiver, toggle_requester]
+      after_action :reset_current_order, only: [:toggle_receiver, :toggle_requester]
 
       def toggle_requester
         spree_current_user&.toggle_requester(@requester)

--- a/app/models/concerns/cenabast/spree/user/store_preference.rb
+++ b/app/models/concerns/cenabast/spree/user/store_preference.rb
@@ -74,7 +74,9 @@ module Cenabast
         # Toggle requester without restrictions
         # Use only for admin users
         def toggle_requester_admin(requester)
-          self.current_receiver = requester.receivers.first
+          return unless (candidate = requester&.receivers&.first)
+
+          self.current_receiver = candidate
           save
         end
 

--- a/app/models/concerns/cenabast/spree/user/store_preference.rb
+++ b/app/models/concerns/cenabast/spree/user/store_preference.rb
@@ -50,9 +50,9 @@ module Cenabast
           return toggle_receiver_admin(receiver) if admin?
           return unless receivers.include? receiver
 
-          reset_current_order
           self.current_receiver = receiver
           save
+          reset_current_order
         end
 
         # Toggle receiver without restrictions
@@ -68,9 +68,9 @@ module Cenabast
           return unless requesters.include? requester
           return unless matching_receivers_for_requester(requester).any?
 
-          reset_current_order
           self.current_receiver = matching_receivers_for_requester(requester).first
           save
+          reset_current_order
         end
 
         # Toggle requester without restrictions

--- a/app/models/concerns/cenabast/spree/user/store_preference.rb
+++ b/app/models/concerns/cenabast/spree/user/store_preference.rb
@@ -50,6 +50,7 @@ module Cenabast
           return toggle_receiver_admin(receiver) if admin?
           return unless receivers.include? receiver
 
+          reset_current_order
           self.current_receiver = receiver
           save
         end
@@ -67,6 +68,7 @@ module Cenabast
           return unless requesters.include? requester
           return unless matching_receivers_for_requester(requester).any?
 
+          reset_current_order
           self.current_receiver = matching_receivers_for_requester(requester).first
           save
         end
@@ -143,6 +145,14 @@ module Cenabast
           receiver = candidate_current_receiver
 
           self[:current_receiver_id] = receiver&.id
+        end
+
+        def reset_current_order
+          # token set to nil forcing to find a new current_order
+          cookies.signed[:token] = nil
+          current_order(create_order_if_necessary: true)
+
+          cookies[:reset_order] = true
         end
       end
     end

--- a/app/models/concerns/cenabast/spree/user/store_preference.rb
+++ b/app/models/concerns/cenabast/spree/user/store_preference.rb
@@ -23,7 +23,6 @@ module Cenabast
           has_many :requesters, -> { distinct }, through: :receivers, class_name: 'Cenabast::Spree::Requester'
 
           before_create :set_current_receiver
-          after_update :reset_current_order, if: :current_receiver_previously_changed?
         end
 
         # For every requester linked should be pickable
@@ -144,14 +143,6 @@ module Cenabast
           receiver = candidate_current_receiver
 
           self[:current_receiver_id] = receiver&.id
-        end
-
-        def reset_current_order
-          # token set to nil forcing to find a new current_order
-          cookies.signed[:token] = nil
-          current_order(create_order_if_necessary: true)
-
-          cookies[:reset_order] = true
         end
       end
     end

--- a/app/models/concerns/cenabast/spree/user/store_preference.rb
+++ b/app/models/concerns/cenabast/spree/user/store_preference.rb
@@ -23,6 +23,7 @@ module Cenabast
           has_many :requesters, -> { distinct }, through: :receivers, class_name: 'Cenabast::Spree::Requester'
 
           before_create :set_current_receiver
+          after_update :reset_current_order, if: :current_receiver_previously_changed?
         end
 
         # For every requester linked should be pickable
@@ -52,7 +53,6 @@ module Cenabast
 
           self.current_receiver = receiver
           save
-          reset_current_order
         end
 
         # Toggle receiver without restrictions
@@ -70,7 +70,6 @@ module Cenabast
 
           self.current_receiver = matching_receivers_for_requester(requester).first
           save
-          reset_current_order
         end
 
         # Toggle requester without restrictions

--- a/app/views/spree/layouts/spree_application.html.erb
+++ b/app/views/spree/layouts/spree_application.html.erb
@@ -23,12 +23,12 @@
     <%= render partial: 'spree/shared/footer' %>
     <%= render 'spree/shared/translations' %>
 
-    <!-- Check if toogle_receiver is active to permit re.execute token fetching -->
-    <% if cookies[:toggle_receiver] %>
+    <% if cookies[:reset_order] %>
+    <!-- Check if :reset_order is active to permit re execute token fetching -->
       <script>
-        Spree.apiTokensFetched = <%= !cookies[:toggle_receiver] %>
+        Spree.apiTokensFetched = <%= !cookies[:reset_order] %>
       </script>
-      <% cookies.delete :toggle_receiver %>
+      <% cookies.delete :reset_order %>
     <% end %>
   </body>
 </html>

--- a/spec/requests/cenabast/spree/user_preferences_spec.rb
+++ b/spec/requests/cenabast/spree/user_preferences_spec.rb
@@ -2,73 +2,292 @@ require 'rails_helper'
 
 RSpec.describe Cenabast::Spree::UserPreferencesController, type: :request do
   describe '#toggle_store' do
-    let(:user) { create(:user) }
-    let(:stores) { create_list(:store, 3) }
-    let(:run) { '111111111' }
+    context 'as non admin user' do
+      let(:user) { create(:user) }
+      let(:stores) { create_list(:store, 3) }
+      let(:run) { '111111111' }
 
-    before do
-      act_as_logged_in(user)
-      @receivers = stores.map do |store|
-        create(:receiver, run:, store:)
+      before do
+        act_as_logged_in(user)
+        @receivers = stores.map do |store|
+          create(:receiver, run:, store:)
+        end
+      end
+
+      it 'can toggle the store to an another allowed one' do
+        user.receivers << @receivers
+        user.current_receiver = user.receivers.sample
+        user.save
+
+        other_receiver = (@receivers - [user.current_receiver]).sample
+        store = other_receiver.store
+
+        post toggle_store_path(option_id: store.id)
+
+        expect(response).to redirect_to(spree.root_path)
+        expect(user.reload.current_store).to eq(store)
+      end
+
+      it 'cant toggle the store to an not allowed one' do
+        user.receivers << @receivers.sample(2)
+        user.current_receiver = user.receivers.sample
+        user.save
+
+        other_receiver = (@receivers - user.receivers).sample
+        store = other_receiver.store
+
+        post toggle_store_path(option_id: store.id)
+
+        expect(response).to redirect_to(spree.root_path)
+        expect(user.reload.current_store).not_to eq(store)
+      end
+
+      it 'redirects back to the spree root path even if location if provided' do
+        post toggle_store_path(option_id: 5), headers: { HTTP_REFERER: '/fallback_location' }
+
+        expect(response).to redirect_to(spree.root_path)
       end
     end
 
-    it 'can toggle the store to an another allowed one' do
-      user.receivers << @receivers
-      user.current_receiver = user.receivers.sample
-      user.save
+    context 'as admin user' do
+      let(:user) { create(:admin_user) }
+      let(:stores) { create_list(:store, 3) }
+      let(:run) { '111111111' }
 
-      other_receiver = (@receivers - [user.current_receiver]).sample
-      store = other_receiver.store
+      before do
+        act_as_logged_in(user)
+        @receivers = stores.map do |store|
+          create(:receiver, run:, store:)
+        end
+      end
 
-      post toggle_store_path(option_id: store.id)
+      it 'can toggle the store to an another allowed one' do
+        user.receivers << @receivers
+        user.current_receiver = user.receivers.sample
+        user.save
 
-      expect(response).to redirect_to(spree.root_path)
-      expect(user.reload.current_store).to eq(store)
-    end
+        other_receiver = (@receivers - [user.current_receiver]).sample
+        store = other_receiver.store
 
-    it 'cant toggle the store to an not allowed one' do
-      user.receivers << @receivers.sample(2)
-      user.current_receiver = user.receivers.sample
-      user.save
+        post toggle_store_path(option_id: store.id)
 
-      other_receiver = (@receivers - user.receivers).sample
-      store = other_receiver.store
+        expect(response).to redirect_to(spree.root_path)
+        expect(user.reload.current_store).to eq(store)
+      end
 
-      post toggle_store_path(option_id: store.id)
+      it 'can toggle the store to an not explicitly allowed one' do
+        user.receivers << @receivers.sample(2)
+        user.current_receiver = user.receivers.sample
+        user.save
 
-      expect(response).to redirect_to(spree.root_path)
-      expect(user.reload.current_store).not_to eq(store)
-    end
+        other_receiver = (@receivers - user.receivers).sample
+        store = other_receiver.store
 
-    it 'redirects back to the spree root path even if location if provided' do
-      post toggle_store_path(option_id: 5), headers: { HTTP_REFERER: '/fallback_location' }
+        post toggle_store_path(option_id: store.id)
 
-      expect(response).to redirect_to(spree.root_path)
+        expect(response).to redirect_to(spree.root_path)
+        expect(user.reload.current_store).to eq(store)
+      end
+
+      it 'redirects back to the spree root path even if location if provided' do
+        post toggle_store_path(option_id: 5), headers: { HTTP_REFERER: '/fallback_location' }
+
+        expect(response).to redirect_to(spree.root_path)
+      end
     end
   end
 
   describe 'POST #toggle_receiver' do
-    let(:user) { create(:user) }
-    let(:receivers) { create_list(:receiver, 3) }
+    context 'as non admin user' do
+      let(:user) { create(:user) }
+      let(:receivers) { create_list(:receiver, 3) }
 
-    before do
-      act_as_logged_in(user)
-      allow(controller).to receive(:spree_current_user).and_return(user)
-      allow(controller).to receive(:current_order).with(create_order_if_necessary: true).
-        and_return(double('Order'))
+      before do
+        act_as_logged_in(user)
+        allow(controller).to receive(:spree_current_user).and_return(user)
+        allow(controller).to receive(:current_order).with(create_order_if_necessary: true).
+          and_return(double('Order'))
+      end
+
+      it 'toggles the receiver for the current user' do
+        user.receivers << receivers
+        user.current_receiver = user.receivers.sample
+        user.save
+        other_receiver = (receivers - [user.current_receiver]).sample
+
+        post toggle_receiver_path(option_id: other_receiver.id)
+
+        expect(user.reload.current_receiver).to eq(other_receiver)
+        expect(response).to redirect_to(spree.root_path)
+      end
+
+      it 'doesnt allow to toggle to a non explicitly given receiver for the current user' do
+        user.receivers << receivers
+        user.current_receiver = user.receivers.sample
+        user.save
+        other_receiver = create_list(:receiver, 3).sample
+
+        post toggle_receiver_path(option_id: other_receiver.id)
+
+        expect(user.reload.current_receiver).not_to eq(other_receiver)
+        expect(response).to redirect_to(spree.root_path)
+      end
+
+      it 'redirects back to fallback location if provided' do
+        post toggle_receiver_path(option_id: 5), headers: { HTTP_REFERER: '/fallback_location' }
+
+        expect(response).to redirect_to('/fallback_location')
+      end
     end
 
-    it 'toggles the receiver for the current user' do
-      user.receivers << receivers
-      user.current_receiver = user.receivers.sample
-      user.save
-      other_receiver = (receivers - [user.current_receiver]).sample
+    context 'as admin user' do
+      let(:user) { create(:admin_user) }
+      let(:receivers) { create_list(:receiver, 3) }
 
-      post toggle_receiver_path(option_id: other_receiver.id)
+      before do
+        act_as_logged_in(user)
+        allow(controller).to receive(:spree_current_user).and_return(user)
+        allow(controller).to receive(:current_order).with(create_order_if_necessary: true).
+          and_return(double('Order'))
+      end
 
-      expect(user.reload.current_receiver).to eq(other_receiver)
-      expect(response).to redirect_to(spree.root_path)
+      it 'toggles the receiver for the current user' do
+        user.receivers << receivers
+        user.current_receiver = user.receivers.sample
+        user.save
+        other_receiver = (receivers - [user.current_receiver]).sample
+
+        post toggle_receiver_path(option_id: other_receiver.id)
+
+        expect(user.reload.current_receiver).to eq(other_receiver)
+        expect(response).to redirect_to(spree.root_path)
+      end
+
+      it 'allows even toggling to a non explicitly given receiver for the current user' do
+        user.receivers << receivers
+        user.current_receiver = user.receivers.sample
+        user.save
+        other_receiver = create_list(:receiver, 3).sample
+
+        post toggle_receiver_path(option_id: other_receiver.id)
+
+        expect(user.reload.current_receiver).to eq(other_receiver)
+        expect(response).to redirect_to(spree.root_path)
+      end
+
+      it 'redirects back to fallback location if provided' do
+        post toggle_receiver_path(option_id: 5), headers: { HTTP_REFERER: '/fallback_location' }
+
+        expect(response).to redirect_to('/fallback_location')
+      end
+    end
+  end
+
+  describe 'POST #toggle_requester' do
+    context 'as non admin user' do
+      let(:user) { create(:user) }
+      let(:receivers) { create_list(:receiver, 3) }
+      let(:requesters) do
+        create_list(:requester, 3) do |requester, i|
+          requester.receiver = receivers[i]
+        end
+      end
+
+      before do
+        act_as_logged_in(user)
+        allow(controller).to receive(:spree_current_user).and_return(user)
+        allow(controller).to receive(:current_order).with(create_order_if_necessary: true).
+          and_return(double('Order'))
+      end
+
+      it 'toggles the requester for the current user' do
+        user.receivers << receivers
+        user.current_receiver = user.receivers.sample
+        user.save
+        other_receiver = (receivers - [user.current_receiver]).sample
+
+        post toggle_requester_path(option_id: other_receiver.requester.id)
+
+        expect(user.reload.current_requester).to eq(other_receiver.requester)
+        expect(response).to redirect_to(spree.root_path)
+      end
+
+      it 'doesnt allow to toggle to a non explicitly given requester for the current user' do
+        user.receivers << receivers
+        user.current_receiver = user.receivers.sample
+        user.save
+        other_receiver = create(:receiver, requester: create(:requester))
+
+        post toggle_requester_path(option_id: other_receiver.requester.id)
+
+        expect(user.reload.current_requester).not_to eq(other_receiver.requester)
+        expect(response).to redirect_to(spree.root_path)
+      end
+
+      it 'redirects back to fallback location if provided' do
+        post toggle_requester_path(option_id: 5), headers: { HTTP_REFERER: '/fallback_location' }
+
+        expect(response).to redirect_to('/fallback_location')
+      end
+    end
+
+    context 'as admin user' do
+      let(:user) { create(:admin_user) }
+      let(:receivers) { create_list(:receiver, 3) }
+      let(:requesters) do
+        create_list(:requester, 3) do |requester, i|
+          requester.receiver = receivers[i]
+        end
+      end
+
+      before do
+        act_as_logged_in(user)
+        allow(controller).to receive(:spree_current_user).and_return(user)
+        allow(controller).to receive(:current_order).with(create_order_if_necessary: true).
+          and_return(double('Order'))
+      end
+
+      it 'toggles the requester for the current user' do
+        user.receivers << receivers
+        user.current_receiver = user.receivers.sample
+        user.save
+        other_receiver = (receivers - [user.current_receiver]).sample
+
+        post toggle_requester_path(option_id: other_receiver.requester.id)
+
+        expect(user.reload.current_requester).to eq(other_receiver.requester)
+        expect(response).to redirect_to(spree.root_path)
+      end
+
+      it 'does not change the requester if an invalid option is given as a parameter' do
+        user.receivers << receivers
+        user.current_receiver = user.receivers.sample
+        user.save
+        current_requester = user.current_requester
+
+        post toggle_requester_path(option_id: 9999)
+
+        expect(user.reload.current_requester).to eq(current_requester)
+        expect(response).to redirect_to(spree.root_path)
+      end
+
+      it 'does allow to toggle to a non explicitly given requester for the current user' do
+        user.receivers << receivers
+        user.current_receiver = user.receivers.sample
+        user.save
+        other_receiver = create(:receiver, requester: create(:requester))
+
+        post toggle_requester_path(option_id: other_receiver.requester.id)
+
+        expect(user.reload.current_requester).to eq(other_receiver.requester)
+        expect(response).to redirect_to(spree.root_path)
+      end
+
+      it 'redirects back to fallback location if provided' do
+        post toggle_requester_path(option_id: 5), headers: { HTTP_REFERER: '/fallback_location' }
+
+        expect(response).to redirect_to('/fallback_location')
+      end
     end
   end
 end


### PR DESCRIPTION
## Link to Issue(s) in JIRA:
- https://linets.atlassian.net/browse/PE188-148
- https://github.com/Departamento-TI/cenabast-tienda/issues/102

## Description

- Fix behaviour for admin users to reload their carts when the requester has changed.
- Add related specs
- Remove "(0)" dummy counter for cart items in header


https://github.com/Departamento-TI/cenabast-tienda/assets/156705333/d95e011e-e780-4090-9b45-6857d9f2a990



## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Rubocop style is passing, and Rspec tests are passing.
- [ ] Documentation has been written (Docs or code)
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
