### PR TITLE
[PE-188-XX] Only allow variants to be purchased if they aren't discontinued

### DIFF
--- a/app/models/cenabast/spree/variant_decorator.rb
+++ b/app/models/cenabast/spree/variant_decorator.rb
@@ -1,0 +1,12 @@
+module Cenabast
+  module Spree
+    module VariantDecorator
+      def purchasable?
+        super && !discontinued? && !product.discontinued?
+      end
+    end
+  end
+end
+
+not_included = Spree::Variant.included_modules.exclude?(Cenabast::Spree::VariantDecorator)
+Spree::Variant.prepend Cenabast::Spree::VariantDecorator if not_included

--- a/app/views/spree/products/_cart_form.html.erb
+++ b/app/views/spree/products/_cart_form.html.erb
@@ -41,6 +41,8 @@
       <%= Spree.t(:availability) %>:
       <% if !is_product_available_in_currency %>
         <%= render 'cart_form_availability_templates', type: 'not-available-in-currency' %>
+      <% elsif default_variant&.product&.discontinued? %>
+        <%= render 'cart_form_availability_templates', type: 'out-of-stock' %>
       <% elsif default_variant.in_stock? %>
         <%= render 'cart_form_availability_templates', type: 'in-stock' %>
       <% elsif default_variant.backorderable? %>

--- a/spec/system/product_page_spec.rb
+++ b/spec/system/product_page_spec.rb
@@ -15,32 +15,78 @@ RSpec.describe 'Visiting Product Page', type: :system do
     act_as_logged_in(user)
     user.toggle_receiver(receiver)
     user.toggle_store(store)
-
-    visit "/products/#{product.slug}"
   end
 
-  it 'should display product`s generic product name' do
-    expect(page).to have_text(product.generic_product.name)
+  context 'product in stock' do
+    before(:each) do
+      product.stock_items.each { |s| s.update(count_on_hand: 10, backorderable: false) }
+
+      visit "/products/#{product.slug}"
+    end
+
+    it 'should display product`s generic product name' do
+      expect(page).to have_text(product.generic_product.name)
+    end
+
+    it 'should display product`s generic product ATC code' do
+      expect(page).to have_text(product.generic_product.code_atc)
+    end
+
+    it 'should display product`s generic product ZGEN code' do
+      expect(page).to have_text(product.generic_product.code)
+    end
+
+    it 'should display product`s contract ZCEN code' do
+      expect(page).to have_text(product.contract.code)
+    end
+
+    it 'should display product`s price on chilean format' do
+      expect(page).to have_text('$5.555')
+    end
+
+    it 'should have link to mercado publico licitation page' do
+      url = "https://www.mercadopublico.cl/Procurement/Modules/RFB/DetailsAcquisition.aspx?idlicitacion=#{product.contract.mercado_publico_id}"
+      expect(page).to have_link(product.contract.mercado_publico_id, href: url)
+    end
+
+    it 'should display that is in stock', js: true do
+      expect(page).to have_text(Spree.t(:in_stock).upcase)
+    end
+
+    it 'should not have add to cart button enabled', js: true do
+      expect(page).to have_selector('#add-to-cart-button')
+    end
   end
 
-  it 'should display product`s generic product ATC code' do
-    expect(page).to have_text(product.generic_product.code_atc)
+  context 'product is out of stock' do
+    before(:each) do
+      product.stock_items.each { |s| s.update(count_on_hand: 0, backorderable: false) }
+
+      visit "/products/#{product.slug}"
+    end
+
+    it 'should display that is out of stock', js: true do
+      expect(page).to have_text(Spree.t(:out_of_stock).upcase)
+    end
+
+    it 'should not have add to cart button enabled', js: true do
+      expect(page).to_not have_selector('#add-to-cart-button')
+    end
   end
 
-  it 'should display product`s generic product ZGEN code' do
-    expect(page).to have_text(product.generic_product.code)
-  end
+  context 'product is discontinued' do
+    before(:each) do
+      product.update(discontinue_on: 3.days.ago)
 
-  it 'should display product`s contract ZCEN code' do
-    expect(page).to have_text(product.contract.code)
-  end
+      visit "/products/#{product.slug}"
+    end
 
-  it 'should display product`s price on chilean format' do
-    expect(page).to have_text('$5.555')
-  end
+    it 'should display that is out of stock', js: true do
+      expect(page).to have_text(Spree.t(:out_of_stock).upcase)
+    end
 
-  it 'should have link to mercado publico licitation page' do
-    url = "https://www.mercadopublico.cl/Procurement/Modules/RFB/DetailsAcquisition.aspx?idlicitacion=#{product.contract.mercado_publico_id}"
-    expect(page).to have_link(product.contract.mercado_publico_id, href: url)
+    it 'should not have add to cart button enabled', js: true do
+      expect(page).to_not have_selector('#add-to-cart-button[enabled]')
+    end
   end
 end


### PR DESCRIPTION
## Link to Issue(s) in JIRA:

## Description

- Only allow variants to be purchased if they aren't discontinued.
- Add behavior on view, to block adding to cart discontinued products
- Add related specs

## Checklist

Before you move on, make sure that:

- [ ] No unintended changes are included
- [ ] Spelling is correct
- [ ] There are tests covering new/changed functionality
- [ ] Rubocop style is passing, and Rspec tests are passing.
- [ ] Documentation has been written (Docs or code)
- [ ] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [ ] Proper labels assigned. Use `WIP` label to indicate that state
